### PR TITLE
release upload command

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+Fabric==1.9.0
+mock==1.0.1
 venv/cache/GitPython-0.3.2.RC1.tar.gz
 venv/cache/argparse-1.2.1.tar.gz
 venv/cache/distribute-0.7.3.zip

--- a/src/cirrus/configuration.py
+++ b/src/cirrus/configuration.py
@@ -63,6 +63,22 @@ class Configuration(dict):
     def organisation_name(self):
         return self.get('package', {}).get('organisation')
 
+    def pypi_url(self):
+        return self.get('pypi', {}).get('pypi_url')
+
+    def pypi_auth(self):
+        return (
+            self.get('pypi', {}).get('pypi_username'),
+            self.get('pypi', {}).get('pypi_password')
+        )
+
+    def pypi_config(self):
+        """
+        get the details for uploading to pypi
+
+        """
+        return self.get('pypi', {})
+
     def gitflow_branch_name(self):
         return self.get('gitflow', {}).get('develop_branch', 'develop')
 

--- a/src/cirrus/fabric_helpers.py
+++ b/src/cirrus/fabric_helpers.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+"""
+_fabric_helpers_
+
+Utils/helpers for fabric api
+
+"""
+import copy
+from fabric.api import env
+
+
+class FabricHelper(object):
+    """
+    _FabricHelper_
+
+    Context helper to set and clear fabric env
+    to run a command on a given host
+
+    Example usage;
+
+    with FabricHelper('pypi.cloudant.com', 'evansde77', '/Users/david/.ssh/id_rsa'):
+        run('/bin/date')
+
+    Will run the date command on pypi.cloudant.com as evansde77 using the key file
+    specified
+    """
+    def __init__(self, hostname, username, ssh_key):
+        self.hostname = hostname
+        self.username = username
+        self.ssh_key = ssh_key
+        # save settings
+        self.hostname_cache = None
+        self.username_cache = None
+        self.ssh_key_cache = None
+
+    def __enter__(self):
+        self.hostname_cache = copy.copy(env.host_string)
+        self.username_cache = copy.copy(env.user)
+        self.ssh_key_cache = copy.copy(env.key_filename)
+
+        env.host_string = self.hostname
+        env.user = self.username
+        env.key_filename = self.ssh_key
+        return self
+
+    def __exit__(self, *args):
+        env.host_string = self.hostname_cache
+        env.user = self.username_cache
+        env.key_filename = self.ssh_key_cache
+
+
+

--- a/tests/unit/cirrus/harnesses.py
+++ b/tests/unit/cirrus/harnesses.py
@@ -16,23 +16,25 @@ import ConfigParser
 from cirrus.configuration import Configuration
 
 
-def write_cirrus_conf(config_file, package, gitflow):
+def write_cirrus_conf(config_file, **sections):
     """
     _write_cirrus_conf_
 
     Util to create a cirrus configuration file and populate it
-    with the settings for the package and gitflow section.
+    with the settings for the package, gitflow, pypi etc sections.
 
-    TODO: better location
+    sections should be nested dict of the form {sectionname: {sectionsettings}}
+
+    Eg:
+
+    settings={'package': {'name': 'package_name'} }
 
     """
     parser = ConfigParser.RawConfigParser()
-    parser.add_section('package')
-    parser.add_section('gitflow')
-    for key, value in package.iteritems():
-        parser.set('package', key, value)
-    for key, value in gitflow.iteritems():
-        parser.set('gitflow', key, value)
+    for section, settings in sections.iteritems():
+        parser.add_section(section)
+        for key, value in settings.iteritems():
+            parser.set(section, key, value)
 
     with open(config_file, 'w') as handle:
         parser.write(handle)
@@ -48,7 +50,7 @@ class CirrusConfigurationHarness(object):
     TODO: better location for this, plus maybe combine with
        generating the cirrus config file
     """
-    def __init__(self, module_symbol, config_file, package=dict(), github=dict() ):
+    def __init__(self, module_symbol, config_file, **settings):
         self.module_symbol = module_symbol
         self.config_file = config_file
 

--- a/tests/unit/cirrus/release_t.py
+++ b/tests/unit/cirrus/release_t.py
@@ -9,6 +9,8 @@ import tempfile
 import mock
 
 from cirrus.release import new_release
+from cirrus.release import upload_release
+from cirrus.release import build_release
 from cirrus.configuration import Configuration
 
 from harnesses import CirrusConfigurationHarness, write_cirrus_conf
@@ -22,8 +24,10 @@ class ReleaseNewCommandTest(unittest.TestCase):
         self.dir = tempfile.mkdtemp()
         self.config = os.path.join(self.dir, 'cirrus.conf')
         write_cirrus_conf(self.config,
-            {'name': 'cirrus_unittest', 'version': '1.2.3'},
-            {'develop_branch': 'develop', 'release_branch_prefix': 'release/'}
+            **{
+                'package': {'name': 'cirrus_unittest', 'version': '1.2.3'},
+                'gitflow': {'develop_branch': 'develop', 'release_branch_prefix': 'release/'},
+                }
             )
         self.harness = CirrusConfigurationHarness('cirrus.release.load_configuration', self.config)
         self.harness.setUp()
@@ -68,6 +72,104 @@ class ReleaseNewCommandTest(unittest.TestCase):
         self.assertEqual(self.mock_branch.call_args[0][1], 'release/1.2.4')
         self.failUnless(self.mock_commit.called)
         self.assertEqual(self.mock_commit.call_args[0][2], 'cirrus.conf')
+
+
+class ReleaseBuildCommandTest(unittest.TestCase):
+    """
+    test case for cirrus release build command
+
+    """
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.config = os.path.join(self.dir, 'cirrus.conf')
+        write_cirrus_conf(self.config,
+            **{
+                'package': {'name': 'cirrus_unittest', 'version': '1.2.3'},
+                'gitflow': {'develop_branch': 'develop', 'release_branch_prefix': 'release/'}
+            }
+            )
+        self.harness = CirrusConfigurationHarness('cirrus.release.load_configuration', self.config)
+        self.harness.setUp()
+
+        self.patch_local =  mock.patch('cirrus.release.local')
+        self.mock_local = self.patch_local.start()
+
+    def tearDown(self):
+        self.harness.tearDown()
+        self.patch_local.stop()
+
+    def test_build_command_raises(self):
+        """should raise when build artifact is not present"""
+        opts = mock.Mock()
+        self.assertRaises(RuntimeError, build_release, opts)
+
+    def test_build_command(self):
+        """test calling build, needs os.path.exists mocks since we arent actually building"""
+        with mock.patch('cirrus.release.os') as mock_os:
+
+            mock_os.path = mock.Mock()
+            mock_os.path.exists = mock.Mock()
+            mock_os.path.exists.return_value = True
+            mock_os.path.join = mock.Mock()
+            mock_os.path.join.return_value = 'build_artifact'
+
+            opts = mock.Mock()
+            result = build_release(opts)
+            self.assertEqual(result, 'build_artifact')
+            self.failUnless(mock_os.path.exists.called)
+            self.assertEqual(mock_os.path.exists.call_args[0][0], 'build_artifact')
+
+            self.failUnless(self.mock_local.called)
+            self.assertEqual(self.mock_local.call_args[0][0], 'python setup.py sdist')
+
+
+class ReleaseUploadCommandTest(unittest.TestCase):
+    """
+    test case for cirrus release upload command
+    """
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.config = os.path.join(self.dir, 'cirrus.conf')
+        write_cirrus_conf(self.config,
+            **{
+                'package' :{'name': 'cirrus_unittest', 'version': '1.2.3'},
+                'github': {'develop_branch': 'develop', 'release_branch_prefix': 'release/'},
+                'pypi': {
+                    'pypi_upload_path': '/opt/pypi',
+                    'pypi_hostname': 'pypi.cloudant.com',
+                    'pypi_username': 'steve',
+                    'pypi_ssh_key': 'steves_creds'
+                }
+            }
+            )
+        self.harness = CirrusConfigurationHarness('cirrus.release.load_configuration', self.config)
+        self.harness.setUp()
+
+        self.patch_put =  mock.patch('cirrus.release.put')
+        self.mock_put = self.patch_put.start()
+
+    def tearDown(self):
+        self.harness.tearDown()
+        self.patch_put.stop()
+
+    def test_release_upload(self):
+        """test upload command, mocking out fabric put"""
+
+        with mock.patch('cirrus.release.os') as mock_os:
+            mock_os.path = mock.Mock()
+            mock_os.path.exists = mock.Mock()
+            mock_os.path.exists.return_value = True
+            mock_os.path.join = mock.Mock()
+            mock_os.path.join.return_value = 'build_artifact'
+
+            opts = mock.Mock()
+            upload_release(opts)
+
+            self.failUnless(mock_os.path.exists.called)
+            self.failUnless(self.mock_put.called)
+            self.assertEqual(self.mock_put.call_args[0][0], 'build_artifact')
+            self.assertEqual(self.mock_put.call_args[0][1], '/opt/pypi' )
+            self.assertEqual(mock_os.path.exists.call_args[0][0], 'build_artifact')
 
 
 


### PR DESCRIPTION
@jcounts 

More work on release commands including adding build and upload commands. 
Build command runs setup.py sdist to create the artifact, upload command uses fabric to send the file 
to the remote server using config settings to get host,user and ssh key for upload. 
Also some test refactor to make the harness more flexible. 
