### PR TITLE
Decrement fields if necessary

### DIFF
--- a/src/cirrus/release.py
+++ b/src/cirrus/release.py
@@ -27,8 +27,6 @@ from cirrus.logger import get_logger
 
 LOGGER = get_logger()
 
-# VERSIONS = {
-#     'MAJOR': 'major'}
 
 def highlander(iterable):
     """check only single True value in iterable"""


### PR DESCRIPTION
@evansde77 
When doing a major release, minor and micro versions are set to 0. When doing a minor release, micro version is set to 0.
