### PR TITLE
Feature/get commit msgs fix

### DIFF
--- a/src/cirrus/github_tools.py
+++ b/src/cirrus/github_tools.py
@@ -142,8 +142,14 @@ def get_commit_msgs(owner, repo, since_sha, token=None):
     resp.raise_for_status()
     result = []
     for commit in resp.json():
+        if commit.get("commiter"):
+            committer = commit['committer']['login']
+        else:
+            # Handle commits that weren't properly identified with a
+            # GitHub user.
+            committer = commit['commit']['committer']['name']
         result.append({
-            "committer" : commit['committer']['login'],
+            "committer" : committer,
             "message":  commit['commit']['message'],
             "date" : commit['commit']['committer']['date']
 


### PR DESCRIPTION
See issue #40 

Here I:
- use the missed params dict in the request to github
- handle missing login information by falling back to the committer name, which is present

@evansde77 @dmannarino @jcounts @petevg
