### PR TITLE
Use unicode format strings for history updates

### DIFF
--- a/src/cirrus/github_tools.py
+++ b/src/cirrus/github_tools.py
@@ -172,12 +172,12 @@ def format_commit_messages(rows):
 
     """
 
-    result = [" - Commit History:"]
+    result = [u" - Commit History:"]
 
     for author, commits in itertools.groupby(rows, lambda x: x['committer']):
-        result.append(" -- Author: {0}".format(author))
+        result.append(u" -- Author: {0}".format(author))
         sorted_commits = sorted([ c for c in commits ], key=lambda x: x['date'], reverse=True)
-        result.extend( ' --- {0}: {1}'.format(commit['date'],commit['message']) for commit in sorted_commits)
+        result.extend( u' --- {0}: {1}'.format(commit['date'],commit['message']) for commit in sorted_commits)
 
     return '\n'.join(result)
 
@@ -237,8 +237,9 @@ def build_release_notes(org, repo, since_tag, formatter):
     msgs = get_commit_msgs(org, repo, sha)
     try:
         rel_notes = FORMATTERS[formatter](msgs)
-    except:
+    except Exception as ex:
+        LOGGER.exception(ex)
         raise RuntimeError(
             ('Invalid release notes formatting: {0} Update cirrus.conf'
-             'entry to use either: plaintext, markdown'.format(formatter)))
+             ' entry to use either: plaintext, markdown'.format(formatter)))
     return rel_notes

--- a/src/cirrus/utils.py
+++ b/src/cirrus/utils.py
@@ -38,7 +38,7 @@ def update_file(filename, sentinel, text):
     with open(filename, 'r') as handle:
         content = handle.read()
 
-    replacement = "{0}\n\n{1}".format(sentinel, text)
+    replacement = u"{0}\n\n{1}".format(sentinel, text)
     content = content.replace(sentinel, replacement, 1)
     with open(filename, 'w') as handle:
         handle.write(content)


### PR DESCRIPTION
  - Using unicode format strings allows us to not choke on message
    from GitHub that may contain a unicode character.

@evansde77 @dmannarino @jcounts @petevg 