### PR TITLE
initial framework for deploy command, plugin fwk and chef deployer

### DIFF
--- a/cirrus.conf
+++ b/cirrus.conf
@@ -20,6 +20,7 @@ feature = cirrus.feature:main
 test = cirrus.test:main
 selfupdate = cirrus.selfupdate:main
 qc = cirrus.quality_control:main
+deploy = cirrus.deploy:main
 
 [quality]
 threshold = 10

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ nose==1.3.0
 pep8==1.5.7
 pylint==1.3.0
 requests==2.3.0
+PyChef==0.2.3
 virtualenv

--- a/src/cirrus/deploy.py
+++ b/src/cirrus/deploy.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+"""
+_deploy_
+
+cirrus deployment command.
+
+Essentially a thin wrapper for the deploy_plugins
+module and its constituent bits
+
+"""
+import sys
+
+from argparse import ArgumentParser
+from cirrus.deploy_plugins import bootstrap_parser, get_plugin
+from cirrus.logger import get_logger
+
+
+LOGGER = get_logger()
+
+
+def build_parser(argslist):
+    """
+    _build_parser_
+
+    Set up command line parser for the deploy command
+
+    """
+    parser = ArgumentParser(
+        description='git cirrus deploy command'
+    )
+    subparsers = parser.add_subparsers(dest='command')
+    bootstrap_parser(subparsers)
+    opts = parser.parse_args(argslist)
+    return opts
+
+
+def main():
+    opts = build_parser(sys.argv)
+    plugin = get_plugin(opts.command)
+    plugin.deploy(opts)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/cirrus/deploy_plugins.py
+++ b/src/cirrus/deploy_plugins.py
@@ -45,13 +45,14 @@ class DeployerRegistry(type):
     """
     def __init__(cls, name, bases, dct):
         pname = getattr(cls, 'plugin_name')
-        if pname is not None:
-            if pname not in _PLUGINS:
-                _PLUGINS[pname] = cls()
-            else:
-                raise RuntimeError(
-                    "Duplicate plugin name: {0}".format(pname)
-                )
+        if name != "DeployerPlugin":
+            assert (pname is not None)
+        if pname not in _PLUGINS:
+            _PLUGINS[pname] = cls()
+        else:
+            raise RuntimeError(
+                "Duplicate plugin name: {0}".format(pname)
+            )
         super(DeployerRegistry, cls).__init__(name, bases, dct)
 
 
@@ -119,6 +120,7 @@ class ChefServerDeployer(DeployerPlugin):
     This assumes your deployment process looks something like:
 
     1. Bump the package version in an env/role/node for some attribute
+       to the current version of this python package
     2. Run pre-chef-client commands on the specified nodes
     3. Run chef-client on the specified nodes
     4. Run post-chef-client commands on the specified nodes

--- a/src/cirrus/deploy_plugins.py
+++ b/src/cirrus/deploy_plugins.py
@@ -40,19 +40,24 @@ class DeployerRegistry(type):
     """
     _DeployerRegistry_
 
-    metaclass to register plugin subclasses with plugins registry
+    metaclass to register plugin subclasses with plugins registry.
+
+    The name that the class will be registered under can be
+    set using the class level plugin_name attribute in the subclass,
+    otherwise it will default to the lowercased class name
 
     """
     def __init__(cls, name, bases, dct):
         pname = getattr(cls, 'plugin_name')
         if name != "DeployerPlugin":
-            assert (pname is not None)
-        if pname not in _PLUGINS:
-            _PLUGINS[pname] = cls()
-        else:
-            raise RuntimeError(
-                "Duplicate plugin name: {0}".format(pname)
-            )
+            if pname is None:
+                pname = name.lower()
+            if pname not in _PLUGINS:
+                _PLUGINS[pname] = cls()
+            else:
+                raise RuntimeError(
+                    "Duplicate plugin name: {0}".format(pname)
+                )
         super(DeployerRegistry, cls).__init__(name, bases, dct)
 
 

--- a/src/cirrus/deploy_plugins.py
+++ b/src/cirrus/deploy_plugins.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+"""
+_deploy_plugins_
+
+Plugin helpers to talk to various deployment platforms
+
+"""
+from cirrus.logger import get_logger
+from cirrus.configuration import load_configuration
+
+
+LOGGER = get_logger()
+_PLUGINS = {}
+
+
+def bootstrap_parser(subparser):
+    """
+    _bootstrap_parser_
+
+    Util to loop through registered plugin instances
+    and call their build_parser hooks to add them to
+    the CLI suite
+
+    """
+    for plugin, instance in _PLUGINS.iteritems():
+        deployer_command = subparser.add_parser(plugin)
+        instance.build_parser(deployer_command)
+
+
+def get_plugin(plugin_name):
+    """
+    _get_plugin_
+
+    Helper to get the plugin instance based on the name
+    """
+    return _PLUGINS.get(plugin_name)
+
+
+class DeployerRegistry(type):
+    """
+    _DeployerRegistry_
+
+    metaclass to register plugin subclasses with plugins registry
+
+    """
+    def __init__(cls, name, bases, dct):
+        pname = getattr(cls, 'plugin_name')
+        if pname is not None:
+            if pname not in _PLUGINS:
+                _PLUGINS[pname] = cls()
+            else:
+                raise RuntimeError(
+                    "Duplicate plugin name: {0}".format(pname)
+                )
+        super(DeployerRegistry, cls).__init__(name, bases, dct)
+
+
+class DeployerPlugin(object):
+    """
+    _DeployerPlugin_
+
+    Base class for Deployer plugins.
+
+    Plugin implementations should inherit this,
+    override the plugin_name attribute (this will be exposed
+        as the command name in the CLI, for example plugin_name="womp"
+        will make the plugin available via git cirrus deploy womp )
+
+    The build_parser method sets up the CLI argparse options for the plugin
+    The deploy method consumes the options namespace from the parser
+    and then executes whatever code it needs to perform the deployment action
+
+    Registry with the plugin framework is handled via the metaclass
+
+    The base class provides some helpers to get at the package
+    and user configuration to allow for config access and customisation
+
+
+    """
+    __metaclass__ = DeployerRegistry
+    plugin_name = None
+
+    def __init__(self):
+        self.package_conf = load_configuration()
+
+    def deploy(self, options):
+        """
+        _deploy_
+
+        :param options: Instance of argparse namespace containing
+        the command line options values
+
+        """
+        raise NotImplementedError(
+            "{0}.deploy not implemented".format(type(self).__name__)
+        )
+
+    def build_parser(self, command_parser):
+        """
+        _build_parser_
+
+        Hook for the plugin to build out its commandline tool
+        suite.
+
+        command_parser is the argparse parser instance for the plugin
+        to add its extensions to
+        """
+        raise NotImplementedError(
+            "{0}.build_parser not implemented".format(type(self).__name__)
+        )
+
+
+class ChefServerDeployer(DeployerPlugin):
+    """
+    _ChefServerDeployer_
+
+    Implement a chef deployment plugin.
+
+    This assumes your deployment process looks something like:
+
+    1. Bump the package version in an env/role/node for some attribute
+    2. Run pre-chef-client commands on the specified nodes
+    3. Run chef-client on the specified nodes
+    4. Run post-chef-client commands on the specified nodes
+
+    This plugin runs chef-client serially and is more suited to
+    a few nodes (eg a CI or integ system) rather than a full
+    scale deployment across many nodes
+
+    """
+    plugin_name = 'chef'
+
+    def deploy(self, **kwargs):
+        """
+        _deploy_
+
+        Implement deployment via chef server.
+
+        """
+        pass
+
+    def build_parser(self, command_parser):
+        """
+        _build_parser_
+
+        construct chef plugin cli options
+
+        """
+        command_parser.add_argument(
+            '--environment', '-e',
+            dest='environment',
+            default=None,
+            help='Chef environment to edit'
+        )
+        command_parser.add_argument(
+            '--role', '-r',
+            dest='role',
+            default=None,
+            help='Chef role to edit'
+            )
+        command_parser.add_argument(
+            '--node', '-n',
+            dest='node',
+            default=None,
+            help='Chef node to edit'
+            )
+        command_parser.add_argument(
+            '--data-bag', '-d',
+            dest='data_bag',
+            default=None,
+            help='Chef data_bag to edit'
+            )
+        command_parser.add_argument(
+            '--attribute', '-a',
+            dest='attribute',
+            required=True,
+            help=(
+                'Version attribute to be bumped as '
+                'name1.name2.attribute style'
+            )
+        )
+        command_parser.add_argument(
+            '--chef-repo',
+            dest='chef_repo',
+            help=(
+                'Location of chef-repo to update '
+                'environment files, if desired'
+            )
+        )
+        command_parser.add_argument(
+            '--nodes-list',
+            dest='node_list',
+            help='list of nodes to execute chef-client on',
+            nargs='+'
+        )


### PR DESCRIPTION
@ksnavely @petevg @jcounts @dmannarino 

Started on the deployment command. No actual deployment yet, just framing out how the command and plugin structure will work to make things not 100% cloudant dependent. 

Our deploy commands should look something like:

git cirrus deploy chef
    --environment=sapi_testing 
    --attribute=override_attributes.cloudant_sapi.applications.installs.wilson 
    --nodes-list= lb.sapitest001 sapi1.sapitest001 
    --chef-repo ../chef-repo 

And this would then bump the specified attr in the environment on the chef server via PyChef, update the chef-repo version of the file and then run chef-client on the listed nodes. 
