### PR TITLE
Feature/version bump flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ git cirrus release upload
 Options:
 
 1. release new requires one of --micro, --minor or --macro to indicate which semantic version field to increment
-2. --bump adds or updates a package==version pair in requirements.txt, e.g. `--bump foo==0.0.9 bar=1.2.3`.
+2. --bump adds or updates a package==version pair in requirements.txt, e.g. `--bump foo==0.0.9 bar==1.2.3`.
 
 
 

--- a/README.md
+++ b/README.md
@@ -63,55 +63,56 @@ git cirrus hello
 
 
 #### cirrus build
-Builds a new virtualenv and installs the requirements for the package, setting up a development/testing/deployment environment for the package. 
+Builds a new virtualenv and installs the requirements for the package, setting up a development/testing/deployment environment for the package.
 
 Usage:
 ```bash
-git cirrus build 
+git cirrus build
 ```
 
-The virtualenv is created in ./venv. 
+The virtualenv is created in ./venv.
 Optional parameters for the build command are read from the cirrus.conf, they are;
 
 1. build Section
   1. virtualenv_name - sets the name of the virtualenv directory, defaults to venv
-  2. requirements_file - name of the requirements.txt file, defaults to requirements.txt 
+  2. requirements_file - name of the requirements.txt file, defaults to requirements.txt
 3. pypi Section
-  4. pypi_url - If present, will use the pypi server to install requirements, also requires the pypi username and token to be set in the cirrus section of your gitconfig  
+  4. pypi_url - If present, will use the pypi server to install requirements, also requires the pypi username and token to be set in the cirrus section of your gitconfig
 
 
 #### cirrus feature
 Commands related to the creatation and management of a git-flow style feature branch.
 
 1. new - Creates a new feature branch, optionally pushing the new branch upstream following a git-flow style workflow
-2. pull-request - Creates a new Pull Request in github requesting to merge the current feature branch with the develop branch, specifying the title, body and list of people to tag in the PR. 
+2. pull-request - Creates a new Pull Request in github requesting to merge the current feature branch with the develop branch, specifying the title, body and list of people to tag in the PR.
 
 Usage:
-```bash 
+```bash
 git cirrus feature new BRANCH_NAME --push
 git cirrus feature pull-request --title TITLE --body BODY --notify @AGITHUBUSER,@ANOTHERGITHUBUSER
 ```
 
 
 #### cirrus release
-Commands related to creation of a new git-flow style release branch, building the release and uploading it to a pypi server. 
+Commands related to creation of a new git-flow style release branch, building the release and uploading it to a pypi server.
 There are three subcommands:
 
-1. new - creates a new release branch, increments the package version, builds the release notes if configured. 
-2. build - Runs sdist to create a new build artifact from the release branch 
-3. upload - Pushes the build artifact to the pypi server configured in the cirrus conf. 
+1. new - creates a new release branch, increments the package version, builds the release notes if configured.
+2. build - Runs sdist to create a new build artifact from the release branch
+3. upload - Pushes the build artifact to the pypi server configured in the cirrus conf.
 
 Usage:
-```bash 
+```bash
 git cirrus test # Stop if things are broken
-git cirrus release new --micro 
-git cirrus release build 
-git cirrus release upload 
+git cirrus release new --micro
+git cirrus release build
+git cirrus release upload
 ```
 
 Options:
 
 1. release new requires one of --micro, --minor or --macro to indicate which semantic version field to increment
+2. --bump adds or updates a package==version pair in requirements.txt, e.g. `--bump foo==0.0.9 bar=1.2.3`.
 
 
 

--- a/src/cirrus/release.py
+++ b/src/cirrus/release.py
@@ -352,12 +352,12 @@ def update_requirements(path, versions):
     file.  Items without '==' are ignored.
 
     Example:
-    ['foo==0.0.9', 'bar==1.2]
+    ['foo==0.0.9', 'bar==1.2']
     """
     LOGGER.info('Updating {}'.format(path))
 
     with open(path, 'r+') as fh:
-        # original requirements.txt it its pristine order
+        # original requirements.txt in its pristine order
         reqs = OrderedDict(tuple(pkg.split('=='))
                            for pkg in fh.readlines() if '==' in pkg)
 

--- a/src/cirrus/release.py
+++ b/src/cirrus/release.py
@@ -178,7 +178,6 @@ def new_release(opts):
 
     config = load_configuration()
 
-    requirements_updated = False
     if opts.bump:
         for pkg in opts.bump:
             if '==' not in pkg:
@@ -187,7 +186,6 @@ def new_release(opts):
                 raise RuntimeError(msg)
         try:
             update_requirements('requirements.txt', opts.bump)
-            requirements_updated = True
         except Exception as ex:
             # halt on any problem updating requirements
             LOGGER.exception('Failed to update requirements.txt -- {}'.format(ex))
@@ -216,7 +214,7 @@ def new_release(opts):
     config.update_package_version(new_version)
     changes = ['cirrus.conf']
 
-    if requirements_updated:
+    if opts.bump:
         changes.append('requirements.txt')
 
     # update release notes file


### PR DESCRIPTION
This PR introduces the `--bump` option to the release command.  This allows you to provide a list of package versions that will update or add to requirements.txt when a release branch is created.

```
. venv/bin/activate
$ python src/cirrus/delegate.py release new --micro --bump foo==0.0.0
```
After running this you can do a `git diff requirements.txt` and you should notice the following:

* Any `package==version` that was not found in requirements.txt will have been added.
* Any `package==version` that already exists in requirements.txt will be updated to the new version.
* Original file order should be preserved.
* New requirements.txt should appear on the new remote release branch.
