### PR TITLE
Option to not use sudo when uploading build artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,10 @@ Options:
 
 1. release new requires one of --micro, --minor or --macro to indicate which semantic version field to increment
 2. --bump adds or updates a package==version pair in requirements.txt, e.g. `--bump foo==0.0.9 bar==1.2.3`.
-
+3. upload will push the new release and upload the build artifact to pypi, but may take several non-required options:
+  * --test do not push new release or upload build artifact to pypi
+  * --no-upload do not upload the build artifact to pypi
+  * --pypi-sudo, --no-pypi-sudo use or do not use sudo to move the build artifact to the correct location in the pypi server, defaults to using sudo
 
 
 *Protip:* If you don't make releases regularly, you'll want to make sure your local repo copy is up to date (cirrus should do these eventually).

--- a/src/cirrus/release.py
+++ b/src/cirrus/release.py
@@ -152,6 +152,19 @@ def build_parser(argslist):
         dest='no_upload',
         help="do not upload build artifact to pypi"
     )
+    upload_command.add_argument(
+        '--pypi-sudo',
+        action='store_true',
+        dest='pypi_sudo',
+        help="use sudo to upload build artifact to pypi"
+    )
+    upload_command.add_argument(
+        '--no-pypi-sudo',
+        action='store_false',
+        dest='pypi_sudo',
+        help="do not use sudo to upload build artifact to pypi"
+    )
+    upload_command.set_defaults(pypi_sudo=True)
 
     opts = parser.parse_args(argslist)
     return opts
@@ -291,7 +304,7 @@ def upload_release(opts):
                 pypi_auth['ssh_key']):
 
             # fabric put the file onto the pypi server
-            put(build_artifact, package_dir, use_sudo=True)
+            put(build_artifact, package_dir, use_sudo=opts.pypi_sudo)
 
     # merge in release branches and tag, push to remote
     tag = config.package_version()


### PR DESCRIPTION
This feature will allow users to upload a release artifact to pypi without using sudo if they have the appropriate permissions as `git cirrus release upload --no-pypi-sudo`. The default remains to use sudo.

A command line option was chosen over a configuration option as the cirrus.conf is tied to the package being developed and not to the developer performing the command.