### PR TITLE
added option to build docs with sphinx/make

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Optional parameters for the build command are read from the cirrus.conf, they ar
   1. `-c, --clean` removes the existing ./venv before building.
   2. `-d, --docs` generate documentation using Sphinx and its generated Makefile.  Any optional make commands can be passed along (e.g., --docs clean singlehtml)
     1.  Requires a `sphinx_makefile_dir` value set in the `docs` section of cirrus.conf.
+    2. `sphinx_makefile_dir` should point to the directory that contains Sphinx's Makefile.
 
 
 #### cirrus feature

--- a/README.md
+++ b/README.md
@@ -14,19 +14,19 @@ curl -O https://raw.githubusercontent.com/evansde77/cirrus/develop/installer.sh
 bash installer.sh
 ```
 
-The installer script will set up an install of cirrus for you in your home directory 
-and prompt for some info so that it can set up some parameters in your .gitconfig 
+The installer script will set up an install of cirrus for you in your home directory
+and prompt for some info so that it can set up some parameters in your .gitconfig
 
 
 
 Installation for Development:
 =============================
 
-_Note_: This package uses GitFlow, any development work should be done off the develop branches and 
-pull requests made against develop, not master. 
+_Note_: This package uses GitFlow, any development work should be done off the develop branches and
+pull requests made against develop, not master.
 
 ```bash
-git clone https://github.com/evansde77/cirrus.git 
+git clone https://github.com/evansde77/cirrus.git
 git cirrus build
 ```
 
@@ -46,14 +46,14 @@ As cirrus works as a git extension, it will use your gitconfig file. The install
 Package Configuration Files:
 ============================
 
-The per package controls used by cirrus live in a cirrus.conf file in the top level of the repo you use with cirrus. 
+The per package controls used by cirrus live in a cirrus.conf file in the top level of the repo you use with cirrus.
 This file, coupled with the cirrus setup.py template and command line tools dictate the behaviour of the cirrus commands within the package. Details for the cirrus config are in the (TBA) Configuration.MD file
 
 
 Cirrus Commands:
-================ 
+================
 
-#### cirrus hello 
+#### cirrus hello
 A simple test command that says hello, verifies that things are working and prints out some info about your cirrus install
 
 Usage:
@@ -76,8 +76,11 @@ Optional parameters for the build command are read from the cirrus.conf, they ar
 1. build Section
   1. virtualenv_name - sets the name of the virtualenv directory, defaults to venv
   2. requirements_file - name of the requirements.txt file, defaults to requirements.txt
-3. pypi Section
-  4. pypi_url - If present, will use the pypi server to install requirements, also requires the pypi username and token to be set in the cirrus section of your gitconfig
+2. pypi Section
+  1. pypi_url - If present, will use the pypi server to install requirements, also requires the pypi username and token to be set in the cirrus section of your gitconfig
+3. Other options
+  1. `-c, --clean` removes the existing ./venv before building.
+  2. `-d, --docs` generate documentation using Sphinx and its generated Makefile.  Any options make commands can be passed along (--docs clean singlehtml)
 
 
 #### cirrus feature
@@ -132,7 +135,7 @@ git checkout develop # you're ready to release!
 Command for running tests in a package.
 
 Usage:
-```bash 
+```bash
 git cirrus test
 ```
 
@@ -148,7 +151,7 @@ May define [test-SUITE_LOCATION] where
 Command for running quality control checks via pylint, pyflakes, pep8.
 
 Usage:
-```bash 
+```bash
 git cirrus qc --files --only-changes --pylint --pyflakes --pep8
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Optional parameters for the build command are read from the cirrus.conf, they ar
   1. pypi_url - If present, will use the pypi server to install requirements, also requires the pypi username and token to be set in the cirrus section of your gitconfig
 3. Other options
   1. `-c, --clean` removes the existing ./venv before building.
-  2. `-d, --docs` generate documentation using Sphinx and its generated Makefile.  Any options make commands can be passed along (--docs clean singlehtml)
+  2. `-d, --docs` generate documentation using Sphinx and its generated Makefile.  Any optional make commands can be passed along (e.g., --docs clean singlehtml)
 
 
 #### cirrus feature

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Optional parameters for the build command are read from the cirrus.conf, they ar
 3. Other options
   1. `-c, --clean` removes the existing ./venv before building.
   2. `-d, --docs` generate documentation using Sphinx and its generated Makefile.  Any optional make commands can be passed along (e.g., --docs clean singlehtml)
+    1.  Requires a `sphinx_makefile_dir` value set in the `docs` section of cirrus.conf.
 
 
 #### cirrus feature

--- a/src/cirrus/build.py
+++ b/src/cirrus/build.py
@@ -20,6 +20,7 @@ from fabric.operations import local
 
 LOGGER = get_logger()
 
+
 def build_parser(argslist):
     """
     _build_parser_
@@ -37,6 +38,12 @@ def build_parser(argslist):
         '--clean',
         action='store_true',
         help='remove existing virtual environment')
+
+    parser.add_argument(
+        '--docs',
+        nargs='*',
+        help='generate documentation with Sphinx (Makefile path must be set in cirrus.conf.')
+
     opts = parser.parse_args(argslist)
     return opts
 
@@ -121,6 +128,41 @@ def execute_build(opts):
     local('. ./{0}/bin/activate && python setup.py develop'.format(venv_name))
 
 
+def build_docs(opts):
+    """
+    _build_docs_
+
+    Runs 'make' against a Sphinx makefile.
+    Requires the following cirrus.conf section:
+
+    [doc]
+    sphinx_makefile_dir = /path/to/makefile
+
+    : param argparse.Namspace opts: A Namespace of build options
+    """
+    LOGGER.info('Building docs')
+    config = load_configuration()
+
+    try:
+        docs_root = os.path.join(os.getcwd(),
+                                 config['doc']['sphinx_makefile_dir'])
+    except KeyError:
+        LOGGER.error('Did not find a complete [doc] section in cirrus.conf'
+                     '\nSee below for an example:'
+                     '\n[doc]'
+                     '\n;sphinx_makefile_dir = /path/to/sphinx')
+        sys.exit(1)
+
+    cmd = 'cd {} && make clean html'.format(docs_root)
+
+    if opts.docs:
+        # additional args were passed after --docs.  Pass these to make
+        cmd = 'cd {} && make {}'.format(docs_root, ' '.join(opts.docs))
+
+    local(cmd)
+    LOGGER.info('Build command was "{}"'.format(cmd))
+
+
 def main():
     """
     _main_
@@ -129,6 +171,9 @@ def main():
     """
     opts = build_parser(sys.argv)
     execute_build(opts)
+
+    if opts.docs is not None:
+        build_docs(opts)
 
 
 if __name__ == '__main__':

--- a/src/cirrus/build.py
+++ b/src/cirrus/build.py
@@ -40,6 +40,7 @@ def build_parser(argslist):
         help='remove existing virtual environment')
 
     parser.add_argument(
+        '-d',
         '--docs',
         nargs='*',
         help='generate documentation with Sphinx (Makefile path must be set in cirrus.conf.')


### PR DESCRIPTION
This PR adds a `--docs` option to launch sphinx builds of python docs using the Makefile generated by sphinx.

Requires a cirrus.conf entry for projects that wish to use this:

```
[docs]
sphinx_makefile_dir = /path/to/makefile
```

If you run `git cirrus build --docs` from cirrus, it should complain that there is no docs section and therefore no docs to build.
