### PR TITLE
activate venv with doc build command

### DIFF
--- a/src/cirrus/build.py
+++ b/src/cirrus/build.py
@@ -143,6 +143,8 @@ def build_docs(opts):
     """
     LOGGER.info('Building docs')
     config = load_configuration()
+    build_params = config.get('build', {})
+    venv_name = build_params.get('virtualenv_name', 'venv')
 
     try:
         docs_root = os.path.join(os.getcwd(),
@@ -160,7 +162,7 @@ def build_docs(opts):
         # additional args were passed after --docs.  Pass these to make
         cmd = 'cd {} && make {}'.format(docs_root, ' '.join(opts.docs))
 
-    local(cmd)
+    local('source ./{}/bin/activate && {}'.format(venv_name, cmd))
     LOGGER.info('Build command was "{}"'.format(cmd))
 
 


### PR DESCRIPTION
This makes sure the local venv is sourced before running the docs build command.

`git cirrus build --docs`