### PR TITLE
Add pypi-url option to release upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Options:
   * --test do not push new release or upload build artifact to pypi
   * --no-upload do not upload the build artifact to pypi
   * --pypi-sudo, --no-pypi-sudo use or do not use sudo to move the build artifact to the correct location in the pypi server, defaults to using sudo
-
+  * --pypi-url URL override the pypi url from cirrus.conf with URL
 
 *Protip:* If you don't make releases regularly, you'll want to make sure your local repo copy is up to date (cirrus should do these eventually).
 

--- a/src/cirrus/release.py
+++ b/src/cirrus/release.py
@@ -146,31 +146,31 @@ def build_parser(argslist):
         '--test',
         action='store_true',
         dest='test',
-        help="test only, do not actually push or upload"
+        help='test only, do not actually push or upload'
     )
     upload_command.add_argument(
         '--no-upload',
         action='store_true',
         dest='no_upload',
-        help="do not upload build artifact to pypi"
+        help='do not upload build artifact to pypi'
     )
     upload_command.add_argument(
         '--pypi-url',
         action='store',
         dest='pypi_url',
-        help="upload to specified pypi url"
+        help='upload to specified pypi url'
     )
     upload_command.add_argument(
         '--pypi-sudo',
         action='store_true',
         dest='pypi_sudo',
-        help="use sudo to upload build artifact to pypi"
+        help='use sudo to upload build artifact to pypi'
     )
     upload_command.add_argument(
         '--no-pypi-sudo',
         action='store_false',
         dest='pypi_sudo',
-        help="do not use sudo to upload build artifact to pypi"
+        help='do not use sudo to upload build artifact to pypi'
     )
     upload_command.set_defaults(pypi_sudo=True)
 

--- a/src/cirrus/release.py
+++ b/src/cirrus/release.py
@@ -155,6 +155,12 @@ def build_parser(argslist):
         help="do not upload build artifact to pypi"
     )
     upload_command.add_argument(
+        '--pypi-url',
+        action='store',
+        dest='pypi_url',
+        help="upload to specified pypi url"
+    )
+    upload_command.add_argument(
         '--pypi-sudo',
         action='store_true',
         dest='pypi_sudo',
@@ -358,10 +364,14 @@ def upload_release(opts):
     else:
         pypi_conf = config.pypi_config()
         pypi_auth = get_pypi_auth()
+        if opts.pypi_url:
+            pypi_url = opts.pypi_url
+        else:
+            pypi_url = pypi_conf['pypi_url']
         package_dir = pypi_conf['pypi_upload_path']
-        LOGGER.info("Uploading {0} to {1}".format(build_artifact, pypi_conf['pypi_url']))
+        LOGGER.info("Uploading {0} to {1}".format(build_artifact, pypi_url))
         with FabricHelper(
-                pypi_conf['pypi_url'],
+                pypi_url,
                 pypi_auth['username'],
                 pypi_auth['ssh_key']):
 


### PR DESCRIPTION
Add an optional '--pypi-url URL' option to the release upload
command which allows a user to override the pypi server url
specified in the cirrus.conf.