### PR TITLE
Fix existing unit tests

### DIFF
--- a/tests/unit/cirrus/quality_control_test.py
+++ b/tests/unit/cirrus/quality_control_test.py
@@ -29,12 +29,12 @@ class QualityControlTest(unittest.TestCase):
         with mock.patch(
             'cirrus.quality_control.pyflakes_file') as mock_pyflakes:
 
-            run_pyflakes()
+            run_pyflakes(False)
             self.failUnless(mock_pyflakes.called)
 
     def test_run_pep8(self):
         with mock.patch('cirrus.quality_control.pep8_file') as mock_pep8:
-            run_pep8()
+            run_pep8(False)
             self.failUnless(mock_pep8.called)
 
 if __name__ == "__main__":

--- a/tests/unit/cirrus/release_test.py
+++ b/tests/unit/cirrus/release_test.py
@@ -56,6 +56,7 @@ class ReleaseNewCommandTest(unittest.TestCase):
         opts.micro = True
         opts.major = False
         opts.minor = False
+        opts.bump = None
 
         # should create a new minor release, editing
         # the cirrus config in the test dir


### PR DESCRIPTION
Fix two existing unit tests to work with changes in
argument parsing and function calls. Note that this
does not increase coverage to newer features.

Sorry, this should have been part of the previous PR.

@cloudant/cloudant-sapi