### PR TITLE
Add option for different pypi ssh user

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ As cirrus works as a git extension, it will use your gitconfig file. The install
 1. *pypi-token* - Token/password to access your pypi server
 1. *pypi-ssh-key* - SSH key used for scp-like uploads to your pypi server (if HTTP upload isnt supported)
 
+*Protip:* If you require a different username for ssh access to your pypi server, you can add an optional *pypi-ssh-user* setting.
 
 Package Configuration Files:
 ============================
@@ -125,6 +126,7 @@ Options:
   * --pypi-url URL override the pypi url from cirrus.conf with URL
 
 *Protip:* If you don't make releases regularly, you'll want to make sure your local repo copy is up to date (cirrus should do these eventually).
+
 
 ```
 git checkout master # get master, if you only have develop

--- a/src/cirrus/configuration.py
+++ b/src/cirrus/configuration.py
@@ -180,10 +180,12 @@ def get_pypi_auth():
     gitconfig_file = os.path.join(os.environ['HOME'], '.gitconfig')
     config = gitconfig.config(gitconfig_file)
     pypi_user = config.get('cirrus', 'pypi-user')
+    pypi_ssh_user = config.get('cirrus', 'pypi-ssh-user')
     pypi_key = config.get('cirrus', 'pypi-ssh-key')
     pypi_token = config.get('cirrus', 'pypi-token')
     return {
         'username': pypi_user,
+        'ssh_username': pypi_ssh_user,
         'ssh_key': pypi_key,
         'token': pypi_token
     }

--- a/src/cirrus/release.py
+++ b/src/cirrus/release.py
@@ -368,11 +368,15 @@ def upload_release(opts):
             pypi_url = opts.pypi_url
         else:
             pypi_url = pypi_conf['pypi_url']
+        if pypi_auth['ssh_username'] is not None:
+            pypi_user = pypi_auth['ssh_username']
+        else:
+            pypi_user = pypi_auth['username']
         package_dir = pypi_conf['pypi_upload_path']
         LOGGER.info("Uploading {0} to {1}".format(build_artifact, pypi_url))
         with FabricHelper(
                 pypi_url,
-                pypi_auth['username'],
+                pypi_user,
                 pypi_auth['ssh_key']):
 
             # fabric put the file onto the pypi server


### PR DESCRIPTION
Add optional configuration setting allowing a different
username for ssh access to pypi server in case the same
username cannot be used for both pip and ssh access to
the server.