### PR TITLE
Gitconfig recovery

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ arrow==0.4.2
 distribute==0.7.3
 Fabric==1.9.0
 GitPython==0.3.2.RC1
-gitconfig==0.0.2
 mock==1.0.1
 nose==1.3.0
 pep8==1.5.7
@@ -11,3 +10,4 @@ pylint==1.3.0
 requests==2.3.0
 PyChef==0.2.3
 virtualenv
+./venv/cache/gitconfig-0.0.2.tar.gz


### PR DESCRIPTION
requirements.txt should point to venv/cache to install gitconfig after some idiot blew it away

```
virtualenv venv
. venv/bin/activate
pip install -r requirements.txt
```

You can also edit the installer.sh script to test with the installer.

Add `git checkout gitconfig_recovery` after the line `cd cirrus`