### PR TITLE
Remove old plugin code and use external lib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ requests==2.3.0
 PyChef==0.2.3
 virtualenv
 ./venv/cache/gitconfig-0.0.2.tar.gz
-pluggage==0.0.3
+pluggage

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ requests==2.3.0
 PyChef==0.2.3
 virtualenv
 ./venv/cache/gitconfig-0.0.2.tar.gz
+pluggage==0.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ requests==2.3.0
 PyChef==0.2.3
 virtualenv
 ./venv/cache/gitconfig-0.0.2.tar.gz
-pluggage==0.0.2
+pluggage==0.0.3

--- a/src/cirrus/deploy.py
+++ b/src/cirrus/deploy.py
@@ -8,17 +8,14 @@ Essentially a thin wrapper for the deploy_plugins
 module and its constituent bits
 
 """
-import sys
-
 from argparse import ArgumentParser
 from cirrus.deploy_plugins import bootstrap_parser, get_plugin
 from cirrus.logger import get_logger
 
-
 LOGGER = get_logger()
 
 
-def build_parser(argslist):
+def build_parser():
     """
     _build_parser_
 
@@ -30,12 +27,12 @@ def build_parser(argslist):
     )
     subparsers = parser.add_subparsers(dest='command')
     bootstrap_parser(subparsers)
-    opts = parser.parse_args(argslist)
+    opts = parser.parse_args()
     return opts
 
 
 def main():
-    opts = build_parser(sys.argv)
+    opts = build_parser()
     plugin = get_plugin(opts.command)
     plugin.deploy(opts)
 


### PR DESCRIPTION
This PR makes use of the pluggage library, specifically to load the chef deployment plugin that is still in progress.