### PR TITLE
Feature/chef repo updates

### DIFF
--- a/src/cirrus/deploy.py
+++ b/src/cirrus/deploy.py
@@ -8,11 +8,21 @@ Essentially a thin wrapper for the deploy_plugins
 module and its constituent bits
 
 """
+import pluggage.registry
 from argparse import ArgumentParser
-from cirrus.deploy_plugins import bootstrap_parser, get_plugin
 from cirrus.logger import get_logger
+from cirrus.configuration import load_configuration
+
 
 LOGGER = get_logger()
+
+
+def get_plugin(plugin_name):
+    factory = pluggage.registry.get_factory(
+        'deploy',
+        load_modules=['cirrus.plugins.deployers']
+    )
+    return factory(plugin_name)
 
 
 def build_parser():
@@ -25,15 +35,30 @@ def build_parser():
     parser = ArgumentParser(
         description='git cirrus deploy command'
     )
-    subparsers = parser.add_subparsers(dest='command')
-    bootstrap_parser(subparsers)
-    opts = parser.parse_args()
+    parser.add_argument(
+        '--plugin', '-p', dest='plugin', default=None,
+        help="Name of deployment plugin to load"
+        )
+    opts, _ = parser.parse_known_args()
     return opts
 
 
 def main():
-    opts = build_parser()
-    plugin = get_plugin(opts.command)
+    initial_opts = build_parser()
+    pname = initial_opts.plugin
+    if initial_opts.plugin is None:
+        config = load_configuration()
+        if 'deploy' not in config:
+            msg = "No Plugin specified with --plugin or in cirrus.conf for deploy"
+            raise RuntimeError(msg)
+        pname = config.get_param('deploy', 'plugin', None)
+    if pname is None:
+        msg = "No Plugin specified with --plugin or in cirrus.conf for deploy"
+        raise RuntimeError(msg)
+
+    plugin = get_plugin(pname)
+    plugin.build_parser()
+    opts = plugin.parser.parse_args()
     plugin.deploy(opts)
 
 

--- a/src/cirrus/deploy.py
+++ b/src/cirrus/deploy.py
@@ -18,6 +18,11 @@ LOGGER = get_logger()
 
 
 def get_plugin(plugin_name):
+    """
+    _get_plugin_
+
+    Get the deploy plugin requested from the factory
+    """
     factory = pluggage.registry.get_factory(
         'deploy',
         load_modules=['cirrus.plugins.deployers']
@@ -44,14 +49,21 @@ def build_parser():
 
 
 def main():
+    """
+    _main_
+
+    Look up the plugin to be invoked for deployment, via the CLI or cirrus config
+    for this package, and then invoke the deployer plugin
+
+    """
     initial_opts = build_parser()
     pname = initial_opts.plugin
     if initial_opts.plugin is None:
         config = load_configuration()
-        if 'deploy' not in config:
-            msg = "No Plugin specified with --plugin or in cirrus.conf for deploy"
-            raise RuntimeError(msg)
-        pname = config.get_param('deploy', 'plugin', None)
+        try:
+            pname = config.get_param('deploy', 'plugin', None)
+        except KeyError:
+            pname = None
     if pname is None:
         msg = "No Plugin specified with --plugin or in cirrus.conf for deploy"
         raise RuntimeError(msg)

--- a/src/cirrus/deploy_plugins.py
+++ b/src/cirrus/deploy_plugins.py
@@ -2,63 +2,29 @@
 """
 _deploy_plugins_
 
-Plugin helpers to talk to various deployment platforms
+Plugin helpers to talk to various deployment platforms,
+Plugins should subclass the Deployer class, override the
+build_parser to handle whatever CLI args they need and
+also deploy to do the actual implementation.
+
+Drop plugins in the cirrus.plugins.deployers dir to get them
+picked up by the plugin factory
 
 """
-from cirrus.logger import get_logger
+import argparse
+
 from cirrus.configuration import load_configuration
-from pluggage.errors import FactoryError
 from pluggage.factory_plugin import PluggagePlugin
-from pluggage.registry import get_factory
-
-LOGGER = get_logger()
-
-# This dict defines which plugin class should handle an ArgumentParser
-# subcommand.  Pluggage allows for multiple plugin classes per factory name, but
-# here we want a single plugin class to handle a single factory name (or in this
-# case, a subcommand)
-_REGISTERED_PLUGINS = {'chef': 'ChefServerDeployer'}
-
-# Plugin instance storage
-_PLUGINS = {}
 
 
-def bootstrap_parser(subparser):
-    """
-    _bootstrap_parser_
-
-    Util to loop through registered plugin instances
-    and call their build_parser hooks to add them to
-    the CLI suite
-    """
-    for plugin_factory, plugin_cls in _REGISTERED_PLUGINS.iteritems():
-        factory = get_factory(plugin_factory)
-        try:
-            instance = factory(plugin_cls)
-        except FactoryError:
-            LOGGER.warn('Could not load plugin "{}"'.format(plugin_cls))
-            continue
-
-        deployer_command = subparser.add_parser(plugin_factory)
-        instance.build_parser(deployer_command)
-
-        # Store the plugin instance with its command name as the key
-        _PLUGINS[plugin_factory] = instance
-
-
-def get_plugin(plugin_name):
-    """
-    _get_plugin_
-
-    Helper to get the plugin instance based on the name
-    """
-    return _PLUGINS.get(plugin_name)
-
-
-class DeployerBase(object):
+class Deployer(PluggagePlugin):
+    PLUGGAGE_FACTORY_NAME = 'deploy'
 
     def __init__(self):
+        super(Deployer, self).__init__()
         self.package_conf = load_configuration()
+        self.parser = argparse.ArgumentParser()
+        self.parser.add_argument('--plugin', '-p', dest='plugin', default=None)
 
     def deploy(self, options):
         """
@@ -72,104 +38,19 @@ class DeployerBase(object):
             "{0}.deploy not implemented".format(type(self).__name__)
         )
 
-    def build_parser(self, command_parser):
+    def build_parser(self):
         """
         _build_parser_
 
         Hook for the plugin to build out its commandline tool
-        suite.
+        suite on self.parser.
 
-        command_parser is the argparse parser instance for the plugin
-        to add its extensions to
+        The master CLI only uses the --plugin option to select the
+        plugin and then passes everything onto that plugin.
+        The plugin parser must allow --plugin, hence the addition
+        of that arg in the base class
+
         """
         raise NotImplementedError(
             "{0}.build_parser not implemented".format(type(self).__name__)
-        )
-
-
-class ChefServerDeployer(DeployerBase, PluggagePlugin):
-    """
-    _ChefServerDeployer_
-
-    Implement a chef deployment plugin.
-
-    This assumes your deployment process looks something like:
-
-    1. Bump the package version in an env/role/node for some attribute
-       to the current version of this python package
-    2. Run pre-chef-client commands on the specified nodes
-    3. Run chef-client on the specified nodes
-    4. Run post-chef-client commands on the specified nodes
-
-    This plugin runs chef-client serially and is more suited to
-    a few nodes (eg a CI or integ system) rather than a full
-    scale deployment across many nodes
-
-    """
-
-    PLUGGAGE_FACTORY_NAME = 'chef'
-
-    def deploy(self, opts):
-        """
-        _deploy_
-
-        Implement deployment via chef server.
-
-        """
-        LOGGER.info('Chef deployment running...')
-        LOGGER.info(opts)
-
-    def build_parser(self, command_parser):
-        """
-        _build_parser_
-
-        construct chef plugin cli options
-
-        """
-        command_parser.add_argument(
-            '--environment', '-e',
-            dest='environment',
-            default=None,
-            help='Chef environment to edit'
-        )
-        command_parser.add_argument(
-            '--role', '-r',
-            dest='role',
-            default=None,
-            help='Chef role to edit'
-            )
-        command_parser.add_argument(
-            '--node', '-n',
-            dest='node',
-            default=None,
-            help='Chef node to edit'
-            )
-        command_parser.add_argument(
-            '--data-bag', '-d',
-            dest='data_bag',
-            default=None,
-            help='Chef data_bag to edit'
-            )
-        command_parser.add_argument(
-            '--attribute', '-a',
-            dest='attribute',
-            required=True,
-            help=(
-                'Version attribute to be bumped as '
-                'name1.name2.attribute style'
-            )
-        )
-        command_parser.add_argument(
-            '--chef-repo',
-            dest='chef_repo',
-            help=(
-                'Location of chef-repo to update '
-                'environment files, if desired'
-            )
-        )
-        command_parser.add_argument(
-            '--nodes-list',
-            dest='node_list',
-            help='list of nodes to execute chef-client on',
-            nargs='+'
         )

--- a/src/cirrus/plugins/deployers/__init__.py
+++ b/src/cirrus/plugins/deployers/__init__.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+"""
+_deployers_
+
+Plugins for the deploy command
+
+"""
+import chef

--- a/src/cirrus/plugins/deployers/chef.py
+++ b/src/cirrus/plugins/deployers/chef.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+"""
+_chef_
+
+Chef deployer plugin
+
+"""
+from cirrus.logger import get_logger
+from cirrus.deploy_plugins import Deployer
+
+
+LOGGER = get_logger()
+
+
+class ChefServerDeployer(Deployer):
+    """
+    _ChefServerDeployer_
+
+    Implement a chef deployment plugin.
+
+    This assumes your deployment process looks something like:
+
+    1. Bump the package version in an env/role/node for some attribute
+       to the current version of this python package
+    2. Run pre-chef-client commands on the specified nodes
+    3. Run chef-client on the specified nodes
+    4. Run post-chef-client commands on the specified nodes
+
+    This plugin runs chef-client serially and is more suited to
+    a few nodes (eg a CI or integ system) rather than a full
+    scale deployment across many nodes
+
+    """
+
+    PLUGGAGE_OBJECT_NAME = 'chef'
+
+    def deploy(self, opts):
+        """
+        _deploy_
+
+        Implement deployment via chef server.
+
+        """
+        LOGGER.info('Chef deployment running...')
+        LOGGER.info(opts)
+
+    def build_parser(self):
+        """
+        _build_parser_
+
+        construct chef plugin cli options
+
+        """
+        self.parser.add_argument(
+            '--environment', '-e',
+            dest='environment',
+            default=None,
+            help='Chef environment to edit'
+        )
+        self.parser.add_argument(
+            '--role', '-r',
+            dest='role',
+            default=None,
+            help='Chef role to edit'
+            )
+        self.parser.add_argument(
+            '--node', '-n',
+            dest='node',
+            default=None,
+            help='Chef node to edit'
+            )
+        self.parser.add_argument(
+            '--data-bag', '-d',
+            dest='data_bag',
+            default=None,
+            help='Chef data_bag to edit'
+            )
+        self.parser.add_argument(
+            '--attribute', '-a',
+            dest='attribute',
+            required=True,
+            help=(
+                'Version attribute to be bumped as '
+                'name1.name2.attribute style'
+            )
+        )
+        self.parser.add_argument(
+            '--chef-repo',
+            dest='chef_repo',
+            help=(
+                'Location of chef-repo to update '
+                'environment files, if desired'
+            )
+        )
+        self.parser.add_argument(
+            '--nodes-list',
+            dest='node_list',
+            help='list of nodes to execute chef-client on',
+            nargs='+'
+        )


### PR DESCRIPTION
@shudgston @petevg 

Refactor of CLI for deploy command to use an initial permissive parser to select the plugin and then make the plugin implement its own parser to handle whatever opts it needs in a way that doesnt require registry gymnastics. 
- Move deployers to cirrus.plugins.deployers 
- More work on the various chef tools to do the deployment 
