### PR TITLE
use fabric to run chef-client

### DIFF
--- a/src/cirrus/configuration.py
+++ b/src/cirrus/configuration.py
@@ -214,7 +214,9 @@ def get_chef_auth():
     return {
         'chef_server': config.get('cirrus', 'chef-server'),
         'chef_username': config.get('cirrus', 'chef-username'),
-        'chef_keyfile': config.get('cirrus', 'chef-keyfile')
+        'chef_keyfile': config.get('cirrus', 'chef-keyfile'),
+        'chef_client_user': config('cirrus', 'chef-client-user'),
+        'chef_client_keyfile': config('cirrus', 'chef-client-keyfile')
     }
 
 

--- a/src/cirrus/plugins/deployers/chef.py
+++ b/src/cirrus/plugins/deployers/chef.py
@@ -113,6 +113,7 @@ class ChefServerDeployer(Deployer):
                 "No chef client user provided, please update your gitconfig"
                 " to include  chef_client_user and chef_client_keyfile"
                 " in the cirrus section"
+            )
             LOGGER.error(msg)
             raise RuntimeError(msg)
 


### PR DESCRIPTION
@shudgston @ksnavely @petevg @appeltel 

This is the final bit, using fabric to run chef-client on the specified nodes. It has to do this in a dumb loop over nodes because fabric is really picky about how its env gets setup