### PR TITLE
[WIP] Cirrus manually sets CI status before pushing a release.

### DIFF
--- a/src/cirrus/git_tools.py
+++ b/src/cirrus/git_tools.py
@@ -137,7 +137,12 @@ def push(repo_dir):
     Push local branch to remote
     """
     repo = git.Repo(repo_dir)
-    return repo.remotes.origin.push(repo.head)
+    ret = repo.remotes.origin.push(repo.head)
+    # Check to make sure that we haven't errored out.
+    for r in ret:
+        if r.flags >= r.ERROR:
+            raise RuntimeError(unicode(r.summary))
+    return ret
 
 
 def tag_release(repo_dir, tag, master='master', push=True):

--- a/src/cirrus/github_tools.py
+++ b/src/cirrus/github_tools.py
@@ -57,7 +57,7 @@ def current_branch_mark_status(repo_dir, state):
     token = get_github_auth()[1]
     sha = git.Repo(repo_dir).head.commit.hexsha
     
-    url = "https://api.github.com/repos/{org}/{repo}/commits/{sha}".format(
+    url = "https://api.github.com/repos/{org}/{repo}/statuses/{sha}".format(
         org=config.organisation_name(),
         repo=config.package_name(),
         sha=sha

--- a/src/cirrus/release.py
+++ b/src/cirrus/release.py
@@ -23,6 +23,7 @@ from cirrus.git_tools import branch, merge
 from cirrus.git_tools import commit_files
 from cirrus.git_tools import tag_release, get_active_branch
 from cirrus.github_tools import branch_status
+from cirrus.github_tools import current_branch_mark_status
 from cirrus.utils import update_file, update_version
 from cirrus.fabric_helpers import FabricHelper
 from cirrus.logger import get_logger
@@ -461,6 +462,11 @@ def upload_release(opts):
     merge(repo_dir, master, expected_branch)
 
     if not opts.test:
+        if release_config['wait_on_ci']:
+            # if wait_on_ci is set and we have gotten to this point,
+            # tests pass on the release branch.
+            LOGGER.info("setting remote status...")
+            current_branch_mark_status(repo_dir, 'success')
         LOGGER.info("pushing to remote...")
         push(repo_dir)
     do_push = not opts.test
@@ -472,6 +478,11 @@ def upload_release(opts):
     checkout_and_pull(repo_dir, develop)
     merge(repo_dir, develop, expected_branch)
     if not opts.test:
+        if release_config['wait_on_ci']:
+            # if wait_on_ci is set and we have gotten to this point,
+            # tests pass on the release branch.
+            LOGGER.info("setting remote status...")
+            current_branch_mark_status(repo_dir, 'success')
         LOGGER.info("pushing to remote...")
         push(repo_dir)
     LOGGER.info("Release {0} has been tagged and uploaded".format(tag))

--- a/tests/unit/cirrus/release_test.py
+++ b/tests/unit/cirrus/release_test.py
@@ -155,12 +155,14 @@ class ReleaseUploadCommandTest(unittest.TestCase):
         self.patch_put.stop()
 
 
+    @mock.patch('cirrus.release.current_branch_mark_status')
+    @mock.patch('cirrus.release.wait_on_gh_status')
     @mock.patch('cirrus.release.get_active_branch')
     @mock.patch('cirrus.release.checkout_and_pull')
     @mock.patch('cirrus.release.merge')
     @mock.patch('cirrus.release.push')
     @mock.patch('cirrus.release.tag_release')
-    def test_release_upload(self, m_tag_release, m_push, m_merge, m_checkout_and_pull, m_get_active_branch ):
+    def test_release_upload(self, m_tag_release, m_push, m_merge, m_checkout_and_pull, m_get_active_branch, m_wait_on_gh_status, m_current_branch_mark_status):
         """test upload command, mocking out fabric put"""
         mock_branch = mock.Mock()
         mock_branch.name = "release/1.2.3"
@@ -190,6 +192,8 @@ class ReleaseUploadCommandTest(unittest.TestCase):
             self.failUnless(m_push.called)
             self.assertEqual(m_push.call_count, 2)
             self.failUnless(m_checkout_and_pull.called)
+
+            self.failUnless(m_current_branch_mark_status.called)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Cirrus already waits until tests have passed on the release
branch. Since it does the merging locally, however, it needs to POST a
status to the develop and master branches, confirming that it has tested
things out, and the CI status is good.

This fixes fb#55653

(Marked as WIP because I haven't done manual testing of the compiled package to make sure that it works.)

@jcounts @evansde77 @ksnavely @shudgston @dmannarino