### PR TITLE
release merge command with optional sha commit comments

### DIFF
--- a/src/cirrus/git_tools.py
+++ b/src/cirrus/git_tools.py
@@ -184,14 +184,18 @@ def merge(repo_dir, source, destination):
     _merge_
 
     Merge source branch into destination branch
+
+    :returns: sha of the last commit from the merged branch
+
     """
     repo = git.Repo(repo_dir)
     repo.git.checkout(source)
 
     ref = "refs/heads/{0}:refs/remotes/origin/{0}".format(source)
     repo.remotes.origin.pull(ref)
-
     repo.git.merge(destination)
+    latest = repo.head.ref.commit.hexsha
+    return latest
 
 
 def get_diff_files(repo_dir):

--- a/src/cirrus/github_tools.py
+++ b/src/cirrus/github_tools.py
@@ -8,8 +8,6 @@ import requests
 
 from cirrus.configuration import get_github_auth, load_configuration
 from cirrus.git_tools import get_active_branch
-from cirrus.git_tools import get_tags_with_sha
-from cirrus.git_tools import get_commit_msgs
 from cirrus.git_tools import push
 from cirrus.logger import get_logger
 
@@ -78,7 +76,6 @@ class GitHubContext(object):
 
         Mark the CI status of the current branch.
 
-        :param repo_dir: directory of git repository
         :param state: state of the last test run, such as "success" or "failure"
         :param context: The GH context string to use for the state, eg
            "continuous-integration/travis-ci"
@@ -108,7 +105,6 @@ class GitHubContext(object):
             repo=self.config.package_name(),
             sha=sha
         )
-        # TODO: context should be a list of possible values from cirrus conf
         data = json.dumps(
             {
                 "state": state,
@@ -303,9 +299,9 @@ def current_branch_mark_status(repo_dir, state):
 
 
 def create_pull_request(
-            repo_dir,
-            pr_info,
-            token=None):
+        repo_dir,
+        pr_info,
+        token=None):
     """
     Creates a pull_request on GitHub and returns the html url of the
     pull request created
@@ -314,7 +310,7 @@ def create_pull_request(
     :param pr_info: dictionary containing title and body of pull request
     :param token: auth token
     """
-    if repo_dir == None:
+    if repo_dir is None:
         raise RuntimeError('repo_dir is None')
     if 'title' not in pr_info:
         raise RuntimeError('title is None')
@@ -341,9 +337,12 @@ def create_pull_request(
 
     resp = requests.post(url, data=json.dumps(data), headers=headers)
     if resp.status_code == 422:
-        LOGGER.error(("POST to GitHub api returned {0}"
-            "Have you committed your changes and pushed to remote?"
-            ).format(resp.status_code))
+        LOGGER.error(
+            (
+                "POST to GitHub api returned {0}"
+                "Have you committed your changes and pushed to remote?"
+            ).format(resp.status_code)
+        )
 
     resp.raise_for_status()
     resp_json = resp.json()
@@ -389,5 +388,5 @@ def get_releases(owner, repo, token=None):
     resp = requests.get(url, headers=headers)
     resp.raise_for_status()
 
-    releases = [ release for release in resp.json() ]
+    releases = [release for release in resp.json()]
     return releases

--- a/src/cirrus/github_tools.py
+++ b/src/cirrus/github_tools.py
@@ -3,6 +3,7 @@ Contains class for handling the creation of pull requests
 '''
 import git
 import json
+import time
 import requests
 
 from cirrus.configuration import get_github_auth, load_configuration
@@ -14,6 +15,138 @@ from cirrus.logger import get_logger
 
 
 LOGGER = get_logger()
+
+
+class GitHubContext(object):
+    """
+    _GitHubContext_
+
+    Util that establishes a GH session and pulls together
+    useful GH commands
+
+    """
+    def __init__(self, repo_dir, package_dir=None):
+        self.repo_dir = repo_dir
+        self.repo = git.Repo(repo_dir)
+        self.config = load_configuration(package_dir)
+        self.token = get_github_auth()[1]
+        self.auth_headers = {
+            'Authorization': 'token {0}'.format(self.token),
+            'Content-Type': 'application/json'
+        }
+
+    @property
+    def active_branch_name(self):
+        """return the current branch name"""
+        return self.repo.active_branch.name
+
+    def __enter__(self):
+        """start context, establish session"""
+        self.session = requests.Session()
+        self.session.headers.update(self.auth_headers)
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    def branch_state(self, branch=None):
+        """
+        _branch_state_
+
+        Get the branch status which should include details of CI builds/hooks etc
+        See:
+        https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
+
+        returns a state which is one of 'failure', 'pending', 'success'
+
+        """
+        if branch is None:
+            branch = self.active_branch_name
+        url = "https://api.github.com/repos/{org}/{repo}/commits/{branch}/status".format(
+            org=self.config.organisation_name(),
+            repo=self.config.package_name(),
+            branch=branch
+        )
+        resp = self.session.get(url)
+        resp.raise_for_status()
+        state = resp.json()['state']
+        return state
+
+    def set_branch_state(self, state, branch=None):
+        """
+        _current_branch_mark_status_
+
+        Mark the CI status of the current branch.
+
+        :param repo_dir: directory of git repository
+        :param state: state of the last test run, such as "success" or "failure"
+
+        """
+        if branch is None:
+            branch = self.repo.active_branch.name
+
+        LOGGER.info(u"Setting CI status for branch {} to {}".format(branch, state))
+
+        sha = self.repo.head.commit.hexsha
+
+        try:
+            # @HACK: Do a push that we expect will fail -- we just want to
+            # tell the server about our sha. A more elegant solution would
+            # probably be to push a detached head.
+            push(self.repo_dir)
+        except RuntimeError as ex:
+            if "rejected" not in unicode(ex):
+                raise
+
+        url = "https://api.github.com/repos/{org}/{repo}/statuses/{sha}".format(
+            org=self.config.organisation_name(),
+            repo=self.config.package_name(),
+            sha=sha
+        )
+
+        data = json.dumps(
+            {
+                "state": state,
+                "description": "State after cirrus check.",
+                #  @HACK: use the travis context, which is technically
+                #  true, because we wait for Travis tests to pass before
+                #  cutting a release. In the future, we need to setup a
+                #  "cirrus" context, for clarity.
+                "context": "continuous-integration/travis-ci"
+            }
+        )
+        resp = self.session.post(url, data=data)
+        resp.raise_for_status()
+
+    def wait_on_gh_status(self, branch_name=None, timeout=600, interval=2):
+        """
+        _wait_on_gh_status_
+
+        Wait for CI checks to complete for the branch named
+
+        :param branch_name: name of branch to watch
+        :param timeout: max wait time in seconds
+        :param interval: pause between checks interval in seconds
+
+        """
+        if branch_name is None:
+            branch_name = self.active_branch_name
+
+        time_spent = 0
+        status = self.branch_state(branch_name)
+        LOGGER.info("Waiting on CI status of {}...".format(branch_name))
+        while status == 'pending':
+            if time_spent > timeout:
+                LOGGER.error("Exceeded timeout for branch status {}".format(branch_name))
+                break
+            status = branch_status(branch_name)
+            time.sleep(interval)
+            time_spent += interval
+
+        if status != 'success':
+            msg = "CI Test status is not success: {} is {}".format(branch_name, status)
+            LOGGER.error(msg)
+            raise RuntimeError(msg)
 
 
 def branch_status(branch_name):
@@ -42,6 +175,7 @@ def branch_status(branch_name):
     resp.raise_for_status()
     state = resp.json()['state']
     return state
+
 
 def current_branch_mark_status(repo_dir, state):
     """
@@ -91,9 +225,10 @@ def current_branch_mark_status(repo_dir, state):
             "context": "continuous-integration/travis-ci"
         }
     )
-
+    print ">>>>", url
     resp = requests.post(url, headers=headers, data=data)
     resp.raise_for_status()
+
 
 def create_pull_request(
             repo_dir,

--- a/src/cirrus/github_tools.py
+++ b/src/cirrus/github_tools.py
@@ -225,7 +225,6 @@ def current_branch_mark_status(repo_dir, state):
             "context": "continuous-integration/travis-ci"
         }
     )
-    print ">>>>", url
     resp = requests.post(url, headers=headers, data=data)
     resp.raise_for_status()
 

--- a/src/cirrus/github_tools.py
+++ b/src/cirrus/github_tools.py
@@ -144,6 +144,29 @@ def create_pull_request(
     return resp_json['html_url']
 
 
+def comment_on_sha(owner, repo, comment, sha, path, token=None):
+    """
+    add a comment to the commit/sha provided
+    """
+    url = "https://api.github.com/repos/{owner}/{repo}/commits/{sha}/comments".format(
+        owner=owner, repo=repo, sha=sha
+    )
+    if token is None:
+        token = get_github_auth()[1]
+
+    headers = {
+        'Authorization': 'token {}'.format(token),
+        'Content-Type': 'application/json'
+    }
+    payload = {
+        "body": comment,
+        "path": path,
+        "position": 0,
+    }
+    resp = requests.get(url, headers=headers, data=payload)
+    resp.raise_for_status()
+
+
 def get_releases(owner, repo, token=None):
 
     url = "https://api.github.com/repos/{owner}/{repo}/releases".format(

--- a/src/cirrus/release.py
+++ b/src/cirrus/release.py
@@ -624,15 +624,6 @@ def merge_release(opts):
     else:
         develop_merge_sha = merge(repo_dir, develop, expected_branch)
 
-    if not opts.test:
-        LOGGER.info("pushing to remote...")
-        if release_config['wait_on_ci']:
-            # if wait_on_ci is set and we have gotten to this point,
-            # tests pass on the release branch, so we can tell the
-            # remote the good news.
-            current_branch_mark_status(repo_dir, 'success')
-        push(repo_dir)
-
     if opts.merge_comment is not None:
         #
         # add the provided comment to the last commit on develop
@@ -644,6 +635,15 @@ def merge_release(opts):
             opts.merge_comment,
             develop_merge_sha,
             path)
+
+    if not opts.test:
+        LOGGER.info("pushing to remote...")
+        if release_config['wait_on_ci']:
+            # if wait_on_ci is set and we have gotten to this point,
+            # tests pass on the release branch, so we can tell the
+            # remote the good news.
+            current_branch_mark_status(repo_dir, 'success')
+        push(repo_dir)
 
     LOGGER.info("Release {0} has been tagged and uploaded".format(tag))
     # TODO: clean up release branch

--- a/src/cirrus/release.py
+++ b/src/cirrus/release.py
@@ -221,12 +221,6 @@ def build_parser(argslist):
         help='test only, do not actually push or upload'
     )
     upload_command.add_argument(
-        '--no-upload',
-        action='store_true',
-        dest='no_upload',
-        help='do not upload build artifact to pypi'
-    )
-    upload_command.add_argument(
         '--pypi-url',
         action='store',
         dest='pypi_url',
@@ -243,19 +237,6 @@ def build_parser(argslist):
         action='store_false',
         dest='pypi_sudo',
         help='do not use sudo to upload build artifact to pypi'
-    )
-    upload_command.add_argument(
-        '--wait-on-ci',
-        action='store_true',
-        dest='wait_on_ci',
-        help='Wait for GH CI status to be success before uploading'
-    )
-    upload_command.add_argument(
-        '--wait-on-ci-timeout',
-        type=int,
-        default=600,
-        dest='wait_on_ci_timeout',
-        help='Seconds to wait on CI before abandoning upload'
     )
     upload_command.set_defaults(pypi_sudo=True)
 
@@ -423,17 +404,6 @@ def upload_release(opts):
 
     build_artifact = artifact_name(config)
     LOGGER.info("Uploading artifact: {0}".format(build_artifact))
-    repo_dir = os.getcwd()
-    curr_branch = get_active_branch(repo_dir)
-    expected_branch = release_branch_name(config)
-
-    if curr_branch.name != expected_branch:
-        msg = (
-            "Not on the expected release branch according "
-            "to cirrus.conf\n Expected:{0} but on {1}"
-        ).format(expected_branch, curr_branch)
-        LOGGER.error(msg)
-        raise RuntimeError(msg)
 
     if not os.path.exists(build_artifact):
         msg = (
@@ -447,7 +417,7 @@ def upload_release(opts):
     tag = config.package_version()
 
     # upload to pypi via fabric over ssh
-    if opts.no_upload or opts.test:
+    if opts.test:
         LOGGER.info("Uploading {} to pypi disabled by test or no-upload option...".format(tag))
     else:
         pypi_conf = config.pypi_config()

--- a/src/cirrus/release.py
+++ b/src/cirrus/release.py
@@ -8,7 +8,6 @@ Implement git cirrus release command
 """
 import os
 import sys
-import time
 import datetime
 import itertools
 from collections import OrderedDict
@@ -18,13 +17,8 @@ from argparse import ArgumentParser
 from cirrus.configuration import load_configuration
 from cirrus.configuration import get_pypi_auth
 from cirrus.git_tools import build_release_notes
-from cirrus.git_tools import checkout_and_pull, push
-from cirrus.git_tools import branch, merge
+from cirrus.git_tools import branch, checkout_and_pull
 from cirrus.git_tools import commit_files
-from cirrus.git_tools import tag_release, get_active_branch
-from cirrus.github_tools import branch_status
-from cirrus.github_tools import current_branch_mark_status
-from cirrus.github_tools import comment_on_sha
 from cirrus.github_tools import GitHubContext
 from cirrus.utils import update_file, update_version
 from cirrus.fabric_helpers import FabricHelper

--- a/src/cirrus/release.py
+++ b/src/cirrus/release.py
@@ -108,7 +108,7 @@ def release_config(config, opts):
     Extract and validate the release config parameters
     from the cirrus config for the package
     """
-    release_config = {
+    release_config_defaults = {
         'wait_on_ci': False,
         'wait_on_ci_timeout': 600,
         'wait_on_ci_interval': 2,
@@ -116,28 +116,29 @@ def release_config(config, opts):
         'update_github_context': False,
     }
 
-    if 'release' in config:
-        release_config['wait_on_ci'] = config.get_param(
-            'release', 'wait_on_ci', False
-        )
-        release_config['wait_on_ci_timeout'] = int(config.get_param(
-            'release', 'wait_on_ci_timeout', 600)
-        )
-        release_config['wait_on_ci_interval'] = int(config.get_param(
-            'release', 'wait_on_ci_interval', 2)
-        )
-        release_config['update_github_context'] = bool(config.get_param(
-            'release', 'update_github_context', False
-        ))
-        release_config['github_context_string'] = config.get_param(
-            'release', 'github_context_string', None
-        )
+    release_config = {}
+    if 'release' not in config:
+        release_config = release_config_defaults
+    else:
+        for key, val in release_config_defaults.iteritems():
+            release_config[key] = config.get_param('release', key, val)
 
     if opts.wait_on_ci:
         release_config['wait_on_ci'] = True
     if opts.github_context_string:
         release_config['update_github_context'] = True
         release_config['github_context_string'] = opts.github_context_string
+
+    # validate argument types
+    release_config['wait_on_ci_timeout'] = int(
+        release_config['wait_on_ci_timeout']
+    )
+    release_config['wait_on_ci_interval'] = int(
+        release_config['wait_on_ci_interval']
+    )
+    release_config['update_github_context'] = bool(
+        release_config['update_github_context']
+    )
 
     if release_config['update_github_context']:
         # require context string


### PR DESCRIPTION
@petevg @shudgston @appeltel 

Jet Lag Code. Probably same as WIP or something. 

In this PR:
 - add new release merge subcommand parser and method
 - clone the merge logic from upload into the new command
 - add support for attaching comments to a commit on merge 

ToDo (more for my benefit): 
  - live testing
  - tweak the file path in the comment to come via cirrus.conf 
  - add branch cleanup on successful merge 
  - clean merge code out of upload command when working
