### PR TITLE
Implement merge skip develop and master

### DIFF
--- a/src/cirrus/release.py
+++ b/src/cirrus/release.py
@@ -249,6 +249,18 @@ def build_parser(argslist):
         dest='cleanup',
         help='Clean up release branch after merging'
     )
+    merge_command.add_argument(
+        '--skip-master',
+        action='store_true',
+        dest='skip_master',
+        help='Skip the master merge and push'
+    )
+    merge_command.add_argument(
+        '--skip-develop',
+        action='store_true',
+        dest='skip_develop',
+        help='Skip the develop merge and push'
+    )
 
     upload_command = subparsers.add_parser('upload')
     upload_command.add_argument(
@@ -517,91 +529,97 @@ def merge_release(opts):
 
         # merge release branch into master
         LOGGER.info("Tagging and pushing {0}".format(tag))
+        if opts.skip_master:
+            LOGGER.info('Skipping merging to {}'.format(master))
+        if opts.skip_develop:
+            LOGGER.info('Skipping merging to {}'.format(develop))
 
-        sha = ghc.repo.head.ref.commit.hexsha
+        if not opts.skip_master:
+            sha = ghc.repo.head.ref.commit.hexsha
 
-        if rel_conf['update_github_context']:
-            LOGGER.info("Setting {} for {}".format(
-                rel_conf['github_context_string'],
-                sha)
-            )
-            ghc.set_branch_state(
-                'success',
-                rel_conf['github_context_string'],
-                branch=sha
-            )
-        if rel_conf['wait_on_ci']:
-            #
-            # wait on release branch CI success
-            #
-            LOGGER.info("Waiting on CI build for {0}".format(release_branch))
-            ghc.wait_on_gh_status(
-                sha,
-                timeout=rel_conf['wait_on_ci_timeout'],
-                interval=rel_conf['wait_on_ci_interval']
-            )
+            if rel_conf['update_github_context']:
+                LOGGER.info("Setting {} for {}".format(
+                    rel_conf['github_context_string'],
+                    sha)
+                )
+                ghc.set_branch_state(
+                    'success',
+                    rel_conf['github_context_string'],
+                    branch=sha
+                )
+            if rel_conf['wait_on_ci']:
+                #
+                # wait on release branch CI success
+                #
+                LOGGER.info("Waiting on CI build for {0}".format(release_branch))
+                ghc.wait_on_gh_status(
+                    sha,
+                    timeout=rel_conf['wait_on_ci_timeout'],
+                    interval=rel_conf['wait_on_ci_interval']
+                )
 
-        LOGGER.info("Merging {} into {}".format(release_branch, master))
-        ghc.pull_branch(master)
-        ghc.merge_branch(release_branch)
-        sha = ghc.repo.head.ref.commit.hexsha
+            LOGGER.info("Merging {} into {}".format(release_branch, master))
+            ghc.pull_branch(master)
+            ghc.merge_branch(release_branch)
+            sha = ghc.repo.head.ref.commit.hexsha
 
-        if rel_conf['update_github_context']:
-            LOGGER.info("Setting {} for {}".format(
-                rel_conf['github_context_string'],
-                sha)
+            if rel_conf['update_github_context']:
+                LOGGER.info("Setting {} for {}".format(
+                    rel_conf['github_context_string'],
+                    sha)
+                )
+                ghc.set_branch_state(
+                    'success',
+                    rel_conf['github_context_string'],
+                    branch=sha
+                )
+            if rel_conf['wait_on_ci_master']:
+                #
+                # wait on release branch CI success
+                #
+                LOGGER.info("Waiting on CI build for {0}".format(master))
+                ghc.wait_on_gh_status(
+                    sha,
+                    timeout=rel_conf['wait_on_ci_timeout'],
+                    interval=rel_conf['wait_on_ci_interval']
+                )
+            ghc.push_branch_with_retry(
+                attempts=rel_conf['push_retry_attempts'],
+                cooloff=rel_conf['push_retry_cooloff']
             )
-            ghc.set_branch_state(
-                'success',
-                rel_conf['github_context_string'],
-                branch=sha
-            )
-        if rel_conf['wait_on_ci_master']:
-            #
-            # wait on release branch CI success
-            #
-            LOGGER.info("Waiting on CI build for {0}".format(master))
-            ghc.wait_on_gh_status(
-                sha,
-                timeout=rel_conf['wait_on_ci_timeout'],
-                interval=rel_conf['wait_on_ci_interval']
-            )
-        ghc.push_branch_with_retry(
-            attempts=rel_conf['push_retry_attempts'],
-            cooloff=rel_conf['push_retry_cooloff']
-        )
-        LOGGER.info("Tagging {} as {}".format(master, tag))
-        ghc.tag_release(tag, master)
+            LOGGER.info("Tagging {} as {}".format(master, tag))
+            ghc.tag_release(tag, master)
 
         LOGGER.info("Merging {} into {}".format(release_branch, develop))
-        ghc.pull_branch(develop)
-        ghc.merge_branch(release_branch)
-        sha = ghc.repo.head.ref.commit.hexsha
+        if not opts.skip_develop:
+            ghc.pull_branch(develop)
+            ghc.merge_branch(release_branch)
+            sha = ghc.repo.head.ref.commit.hexsha
 
-        if rel_conf['update_github_context']:
-            LOGGER.info("Setting {} for {}".format(
-                rel_conf['github_context_string'],
-                sha)
+            if rel_conf['update_github_context']:
+                LOGGER.info("Setting {} for {}".format(
+                    rel_conf['github_context_string'],
+                    sha)
+                )
+                ghc.set_branch_state(
+                    'success',
+                    rel_conf['github_context_string'],
+                    branch=sha
+                )
+            if rel_conf['wait_on_ci_develop']:
+                #
+                # wait on release branch CI success
+                #
+                LOGGER.info("Waiting on CI build for {0}".format(develop))
+                ghc.wait_on_gh_status(
+                    sha,
+                    timeout=rel_conf['wait_on_ci_timeout'],
+                    interval=rel_conf['wait_on_ci_interval']
+                )
+            ghc.push_branch_with_retry(
+                attempts=rel_conf['push_retry_attempts'],
+                cooloff=rel_conf['push_retry_cooloff']
             )
-            ghc.set_branch_state(
-                'success',
-                rel_conf['github_context_string'],
-                branch=sha
-            )
-        if rel_conf['wait_on_ci_develop']:
-            #
-            # wait on release branch CI success
-            #
-            LOGGER.info("Waiting on CI build for {0}".format(develop))
-            ghc.wait_on_gh_status(
-                sha,
-                timeout=rel_conf['wait_on_ci_timeout'],
-                interval=rel_conf['wait_on_ci_interval']
-            )
-        ghc.push_branch_with_retry(
-            attempts=rel_conf['push_retry_attempts'],
-            cooloff=rel_conf['push_retry_cooloff']
-        )
         if opts.cleanup:
             ghc.delete_branch(release_branch)
 

--- a/src/cirrus/release.py
+++ b/src/cirrus/release.py
@@ -521,24 +521,24 @@ def merge_release(opts):
         expected_branch = release_branch_name(config)
         if release_branch != expected_branch:
             msg = (
-                "Not on the expected release branch according "
-                "to cirrus.conf\n Expected:{0} but on {1}"
+                u"Not on the expected release branch according "
+                u"to cirrus.conf\n Expected:{0} but on {1}"
             ).format(expected_branch, release_branch)
             LOGGER.error(msg)
             raise RuntimeError(msg)
 
         # merge release branch into master
-        LOGGER.info("Tagging and pushing {0}".format(tag))
+        LOGGER.info(u"Tagging and pushing {0}".format(tag))
         if opts.skip_master:
-            LOGGER.info('Skipping merging to {}'.format(master))
+            LOGGER.info(u'Skipping merging to {}'.format(master))
         if opts.skip_develop:
-            LOGGER.info('Skipping merging to {}'.format(develop))
+            LOGGER.info(u'Skipping merging to {}'.format(develop))
 
         if not opts.skip_master:
             sha = ghc.repo.head.ref.commit.hexsha
 
             if rel_conf['update_github_context']:
-                LOGGER.info("Setting {} for {}".format(
+                LOGGER.info(u"Setting {} for {}".format(
                     rel_conf['github_context_string'],
                     sha)
                 )
@@ -551,20 +551,20 @@ def merge_release(opts):
                 #
                 # wait on release branch CI success
                 #
-                LOGGER.info("Waiting on CI build for {0}".format(release_branch))
+                LOGGER.info(u"Waiting on CI build for {0}".format(release_branch))
                 ghc.wait_on_gh_status(
                     sha,
                     timeout=rel_conf['wait_on_ci_timeout'],
                     interval=rel_conf['wait_on_ci_interval']
                 )
 
-            LOGGER.info("Merging {} into {}".format(release_branch, master))
+            LOGGER.info(u"Merging {} into {}".format(release_branch, master))
             ghc.pull_branch(master)
             ghc.merge_branch(release_branch)
             sha = ghc.repo.head.ref.commit.hexsha
 
             if rel_conf['update_github_context']:
-                LOGGER.info("Setting {} for {}".format(
+                LOGGER.info(u"Setting {} for {}".format(
                     rel_conf['github_context_string'],
                     sha)
                 )
@@ -577,7 +577,7 @@ def merge_release(opts):
                 #
                 # wait on release branch CI success
                 #
-                LOGGER.info("Waiting on CI build for {0}".format(master))
+                LOGGER.info(u"Waiting on CI build for {0}".format(master))
                 ghc.wait_on_gh_status(
                     sha,
                     timeout=rel_conf['wait_on_ci_timeout'],
@@ -587,17 +587,17 @@ def merge_release(opts):
                 attempts=rel_conf['push_retry_attempts'],
                 cooloff=rel_conf['push_retry_cooloff']
             )
-            LOGGER.info("Tagging {} as {}".format(master, tag))
+            LOGGER.info(u"Tagging {} as {}".format(master, tag))
             ghc.tag_release(tag, master)
 
-        LOGGER.info("Merging {} into {}".format(release_branch, develop))
+        LOGGER.info(u"Merging {} into {}".format(release_branch, develop))
         if not opts.skip_develop:
             ghc.pull_branch(develop)
             ghc.merge_branch(release_branch)
             sha = ghc.repo.head.ref.commit.hexsha
 
             if rel_conf['update_github_context']:
-                LOGGER.info("Setting {} for {}".format(
+                LOGGER.info(u"Setting {} for {}".format(
                     rel_conf['github_context_string'],
                     sha)
                 )
@@ -610,7 +610,7 @@ def merge_release(opts):
                 #
                 # wait on release branch CI success
                 #
-                LOGGER.info("Waiting on CI build for {0}".format(develop))
+                LOGGER.info(u"Waiting on CI build for {0}".format(develop))
                 ghc.wait_on_gh_status(
                     sha,
                     timeout=rel_conf['wait_on_ci_timeout'],


### PR DESCRIPTION
@ksnavely @appeltel @shudgston 
Support skipping merging to branches in merge command so that it is easier to retry merges on protected branches that partially work