### PR TITLE
Feature/auth plugins

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pep8==1.5.7
 pylint==1.3.0
 requests==2.3.0
 PyChef==0.2.3
+keyring==8.5.1
 virtualenv
 ./venv/cache/gitconfig-0.0.2.tar.gz
 pluggage

--- a/src/cirrus/configuration.py
+++ b/src/cirrus/configuration.py
@@ -36,9 +36,10 @@ class Configuration(dict):
     _Configuration_
 
     """
-    def __init__(self, config_file):
+    def __init__(self, config_file, gitconfig_file=None):
         super(Configuration, self).__init__(self)
         self.config_file = config_file
+        self.gitconfig_file = gitconfig_file
         self.parser = None
         self.credentials = None
         self.gitconfig = None
@@ -59,8 +60,9 @@ class Configuration(dict):
                     option,
                     self.parser.get(section, option)
                 )
-        gitconfig_file = os.path.join(os.environ['HOME'], '.gitconfig')
-        self.gitconfig = gitconfig.config(gitconfig_file)
+        if self.gitconfig_file is None:
+            self.gitconfig_file = os.path.join(os.environ['HOME'], '.gitconfig')
+        self.gitconfig = gitconfig.config(self.gitconfig_file)
         self._load_creds_plugin()
 
     def _load_creds_plugin(self):
@@ -168,14 +170,15 @@ def _repo_directory():
     return outp.strip()
 
 
-def load_configuration(package_dir=None):
+def load_configuration(package_dir=None, gitconfig_file=None):
     """
     _load_configuration_
 
     Load the cirrus.conf file and parse it into a nested dictionary
     like Configuration instance.
 
-    :params package_dir: Location of cirrus managed package if not pwd
+    :param package_dir: Location of cirrus managed package if not pwd
+    :param gitconfig_file: Path to gitconfig if not ~/.gitconfig
     :returns: Configuration instance
 
     """
@@ -192,7 +195,7 @@ def load_configuration(package_dir=None):
         msg = "Couldnt find ./cirrus.conf, are you in a package directory?"
         raise RuntimeError(msg)
 
-    config_instance = Configuration(config_path)
+    config_instance = Configuration(config_path, gitconfig_file=gitconfig_file)
     config_instance.load()
     return config_instance
 
@@ -202,6 +205,8 @@ def get_github_auth():
     _get_git_auth_
 
     Pull in github auth user & token from gitconfig
+
+    DEPRECATED: use Configuration.credentials instead
     """
     gitconfig_file = os.path.join(os.environ['HOME'], '.gitconfig')
     config = gitconfig.config(gitconfig_file)
@@ -215,6 +220,7 @@ def get_pypi_auth():
     _pypi_auth_
 
     Get pypi credentials from gitconfig
+    DEPRECATED: use Configuration.credentials instead
 
     """
     gitconfig_file = os.path.join(os.environ['HOME'], '.gitconfig')
@@ -236,6 +242,7 @@ def get_buildserver_auth():
     _buildserver_auth_
 
     Get buildserver credentials from gitconfig
+    DEPRECATED: use Configuration.credentials instead
 
     """
     gitconfig_file = os.path.join(os.environ['HOME'], '.gitconfig')
@@ -247,6 +254,7 @@ def get_buildserver_auth():
 def get_chef_auth():
     """
     get chef auth info from gitconfig
+    DEPRECATED: use Configuration.credentials instead
 
     """
     gitconfig_file = os.path.join(os.environ['HOME'], '.gitconfig')

--- a/src/cirrus/creds_plugin.py
+++ b/src/cirrus/creds_plugin.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env
+"""
+creds_plugin
+
+"""
+import inspect
+from pluggage.factory_plugin import PluggagePlugin
+
+
+class CredsPlugin(PluggagePlugin):
+    """
+    base class for a credential manager plugin.
+    Subclasses should override the load and *_credentials
+    methods to return the equivalent dictionary containing
+    the required creds
+
+    """
+    PLUGGAGE_FACTORY_NAME = 'credentials'
+
+    def __init__(self):
+        super(CredsPlugin, self).__init__()
+        self.load()
+
+    def load(self):
+        """override to do any loading steps needed"""
+        pass
+
+    def github_credentials(self):
+        return {
+            'github_user': None,
+            'github_token': None
+        }
+
+    def pypi_credentials(self):
+        return {
+            'username': None,
+            'token': None,
+        }
+
+    def ssh_credentials(self):
+        return {
+            'ssh_username': None,
+            'ssh_key': None
+        }
+
+    def buildserver_credentials(self):
+        return {
+            'buildserver-user': None,
+            'buildserver-token': None
+        }
+
+    def chef_credentials(self):
+        return {
+            'chef_server': None,
+            'chef_username': None,
+            'chef_keyfile': None,
+            'chef_client_user': None,
+            'chef_client_keyfile': None,
+        }
+
+    def dockerhub_credentials(self):
+        return {
+            'username': None,
+            'email': None,
+            'password': None
+        }
+
+
+    def credential_methods(self):
+        match = lambda x: inspect.ismethod(x) and x.__name__.endswith('_credentials')
+        return [x for x in inspect.getmembers(self, predicate=match)]
+
+    def credential_map(self):
+        result = {}
+        for m_name, m_func in self.credential_methods():
+            result[m_name] = m_func()
+
+        return result
+
+
+if __name__ == '__main__':
+    x = CredsPlugin()
+    print x.credential_map()
+

--- a/src/cirrus/creds_plugin.py
+++ b/src/cirrus/creds_plugin.py
@@ -65,20 +65,21 @@ class CredsPlugin(PluggagePlugin):
             'password': None
         }
 
-
     def credential_methods(self):
+        """
+        helper to grab all the *_credentials methods on this class
+        """
         match = lambda x: inspect.ismethod(x) and x.__name__.endswith('_credentials')
         return [x for x in inspect.getmembers(self, predicate=match)]
 
     def credential_map(self):
+        """
+        produces a nested credential dictionary that can be used
+        to render templates with a standard format for looking
+        up a credential
+
+        """
         result = {}
         for m_name, m_func in self.credential_methods():
             result[m_name] = m_func()
-
         return result
-
-
-if __name__ == '__main__':
-    x = CredsPlugin()
-    print x.credential_map()
-

--- a/src/cirrus/plugins/creds/__init__.py
+++ b/src/cirrus/plugins/creds/__init__.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+"""
+_creds_
+
+Credential getter plugins to avoid having to have credentials
+in flat files and use password managers etc where available
+
+"""
+import default

--- a/src/cirrus/plugins/creds/default.py
+++ b/src/cirrus/plugins/creds/default.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+"""
+default
+
+Default credential management that gets things from
+your .gitconfig.
+
+"""
+import os
+import gitconfig
+from cirrus.creds_plugin import CredsPlugin
+
+
+class Default(CredsPlugin):
+    """
+    Default
+
+    Get credentials from the users ~/.gitconfig file
+
+    """
+    PLUGGAGE_OBJECT_NAME = 'default'
+
+    def __init__(self):
+        super(Default, self).__init__()
+
+    def load(self):
+        """
+        load - override load hook to read the users .gitconfig file
+        """
+        gitconfig_file = os.path.join(os.environ['HOME'], '.gitconfig')
+        self.config = gitconfig.config(gitconfig_file)
+
+    def github_credentials(self):
+        github_user = self.config.get('cirrus', 'github-user')
+        github_token = self.config.get('cirrus', 'github-token')
+        return {
+            'github_user': github_user,
+            'github_token': github_token
+        }
+
+    def pypi_credentials(self):
+        pypi_user = self.config.get('cirrus', 'pypi-user')
+        pypi_token = self.config.get('cirrus', 'pypi-token')
+        return {
+            'username': pypi_user,
+            'token': pypi_token
+        }
+
+    def ssh_credentials(self):
+        pypi_ssh_user = self.config.get('cirrus', 'ssh-user')
+        pypi_key = self.config.get('cirrus', 'ssh-key')
+        return {
+            'ssh_username': pypi_ssh_user,
+            'ssh_key': pypi_key
+        }
+
+    def buildserver_credentials(self):
+        """
+
+        """
+        return {
+            'buildserver-user': self.config.get('cirrus', 'buildserver-user'),
+            'buildserver-token': self.config.get('cirrus', 'buildserver-token')
+        }
+
+    def chef_credentials(self):
+        """
+
+        """
+        return {
+            'chef_server': self.config.get('cirrus', 'chef-server'),
+            'chef_username': self.config.get('cirrus', 'chef-username'),
+            'chef_keyfile': self.config.get('cirrus', 'chef-keyfile'),
+            'chef_client_user': self.config.get('cirrus', 'chef-client-user'),
+            'chef_client_keyfile': self.config.get('cirrus', 'chef-client-keyfile')
+        }
+
+    def dockerhub_credentials(self):
+        return {
+            'username': self.config.get_param('cirrus', 'docker_login_username', None),
+            'email': self.config.get_param('cirrus', 'docker_login_email', None),
+            'password': self.config.get_param('cirrus', 'docker_login_password', None)
+        }

--- a/src/cirrus/plugins/creds/default.py
+++ b/src/cirrus/plugins/creds/default.py
@@ -20,15 +20,17 @@ class Default(CredsPlugin):
     """
     PLUGGAGE_OBJECT_NAME = 'default'
 
-    def __init__(self):
+    def __init__(self, gitconfig_file=None):
+        self.gitconfig_file = gitconfig_file
         super(Default, self).__init__()
 
     def load(self):
         """
         load - override load hook to read the users .gitconfig file
         """
-        gitconfig_file = os.path.join(os.environ['HOME'], '.gitconfig')
-        self.config = gitconfig.config(gitconfig_file)
+        if self.gitconfig_file is None:
+            self.gitconfig_file = os.path.join(os.environ['HOME'], '.gitconfig')
+        self.config = gitconfig.config(self.gitconfig_file)
 
     def github_credentials(self):
         github_user = self.config.get('cirrus', 'github-user')
@@ -77,7 +79,7 @@ class Default(CredsPlugin):
 
     def dockerhub_credentials(self):
         return {
-            'username': self.config.get_param('cirrus', 'docker_login_username', None),
-            'email': self.config.get_param('cirrus', 'docker_login_email', None),
-            'password': self.config.get_param('cirrus', 'docker_login_password', None)
+            'username': self.config.get('cirrus', 'docker_login_username'),
+            'email': self.config.get('cirrus', 'docker_login_email'),
+            'password': self.config.get('cirrus', 'docker_login_password')
         }

--- a/src/cirrus/plugins/creds/keyring.py
+++ b/src/cirrus/plugins/creds/keyring.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+"""
+keyring module plugin
+
+"""
+import keyring
+from cirrus.creds_plugin import CredsPlugin
+
+
+class Keyring(CredsPlugin):
+    """
+    Keyring
+
+    Get credentials from the platform's keyring implementation
+    Eg: Keychain on OSX
+    See https://pypi.python.org/pypi/keyring for more details
+
+    """
+    PLUGGAGE_OBJECT_NAME = 'keyring'
+
+    def __init__(self):
+        super(Keyring, self).__init__()
+        self.section = "cirrus"
+        self.keyring = None
+
+    def load(self):
+        """
+        """
+        self.keyring = keyring.get_keyring()
+
+    def github_credentials(self):
+        github_user = self.keyring.get_password('cirrus', 'github-user')
+        github_token = self.keyring.get_password('cirrus', 'github-token')
+        return {
+            'github_user': github_user,
+            'github_token': github_token
+        }
+
+    def pypi_credentials(self):
+        pypi_user = self.keyring.get_password('cirrus', 'pypi-user')
+        pypi_token = self.keyring.get_password('cirrus', 'pypi-token')
+        return {
+            'username': pypi_user,
+            'token': pypi_token
+        }
+
+    def ssh_credentials(self):
+        pypi_ssh_user = self.keyring.get_password('cirrus', 'ssh-user')
+        pypi_key = self.keyring.get_password('cirrus', 'ssh-key')
+        return {
+            'ssh_username': pypi_ssh_user,
+            'ssh_key': pypi_key
+        }
+
+    def buildserver_credentials(self):
+        """
+
+        """
+        return {
+            'buildserver-user': self.keyring.get_password('cirrus', 'buildserver-user'),
+            'buildserver-token': self.keyring.get_password('cirrus', 'buildserver-token')
+        }
+
+    def chef_credentials(self):
+        """
+
+        """
+        return {
+            'chef_server': self.keyring.get_password('cirrus', 'chef-server'),
+            'chef_username': self.keyring.get_password('cirrus', 'chef-username'),
+            'chef_keyfile': self.keyring.get_password('cirrus', 'chef-keyfile'),
+            'chef_client_user': self.keyring.get_password('cirrus', 'chef-client-user'),
+            'chef_client_keyfile': self.keyring.get_password('cirrus', 'chef-client-keyfile')
+        }
+
+    def dockerhub_credentials(self):
+        return {
+            'username': self.config.get_param('cirrus', 'docker_login_username', None),
+            'email': self.config.get_param('cirrus', 'docker_login_email', None),
+            'password': self.config.get_param('cirrus', 'docker_login_password', None)
+        }

--- a/src/cirrus/plugins/creds/keyring.py
+++ b/src/cirrus/plugins/creds/keyring.py
@@ -19,34 +19,35 @@ class Keyring(CredsPlugin):
     PLUGGAGE_OBJECT_NAME = 'keyring'
 
     def __init__(self):
-        super(Keyring, self).__init__()
-        self.section = "cirrus"
         self.keyring = None
+        self.section = "cirrus"
+        super(Keyring, self).__init__()
 
     def load(self):
         """
+        load current keyring object
         """
         self.keyring = keyring.get_keyring()
 
     def github_credentials(self):
-        github_user = self.keyring.get_password('cirrus', 'github-user')
-        github_token = self.keyring.get_password('cirrus', 'github-token')
+        github_user = self.keyring.get_password(self.section, 'github-user')
+        github_token = self.keyring.get_password(self.section, 'github-token')
         return {
             'github_user': github_user,
             'github_token': github_token
         }
 
     def pypi_credentials(self):
-        pypi_user = self.keyring.get_password('cirrus', 'pypi-user')
-        pypi_token = self.keyring.get_password('cirrus', 'pypi-token')
+        pypi_user = self.keyring.get_password(self.section, 'pypi-user')
+        pypi_token = self.keyring.get_password(self.section, 'pypi-token')
         return {
             'username': pypi_user,
             'token': pypi_token
         }
 
     def ssh_credentials(self):
-        pypi_ssh_user = self.keyring.get_password('cirrus', 'ssh-user')
-        pypi_key = self.keyring.get_password('cirrus', 'ssh-key')
+        pypi_ssh_user = self.keyring.get_password(self.section, 'ssh-user')
+        pypi_key = self.keyring.get_password(self.section, 'ssh-key')
         return {
             'ssh_username': pypi_ssh_user,
             'ssh_key': pypi_key
@@ -57,8 +58,8 @@ class Keyring(CredsPlugin):
 
         """
         return {
-            'buildserver-user': self.keyring.get_password('cirrus', 'buildserver-user'),
-            'buildserver-token': self.keyring.get_password('cirrus', 'buildserver-token')
+            'buildserver-user': self.keyring.get_password(self.section, 'buildserver-user'),
+            'buildserver-token': self.keyring.get_password(self.section, 'buildserver-token')
         }
 
     def chef_credentials(self):
@@ -66,16 +67,16 @@ class Keyring(CredsPlugin):
 
         """
         return {
-            'chef_server': self.keyring.get_password('cirrus', 'chef-server'),
-            'chef_username': self.keyring.get_password('cirrus', 'chef-username'),
-            'chef_keyfile': self.keyring.get_password('cirrus', 'chef-keyfile'),
-            'chef_client_user': self.keyring.get_password('cirrus', 'chef-client-user'),
-            'chef_client_keyfile': self.keyring.get_password('cirrus', 'chef-client-keyfile')
+            'chef_server': self.keyring.get_password(self.section, 'chef-server'),
+            'chef_username': self.keyring.get_password(self.section, 'chef-username'),
+            'chef_keyfile': self.keyring.get_password(self.section, 'chef-keyfile'),
+            'chef_client_user': self.keyring.get_password(self.section, 'chef-client-user'),
+            'chef_client_keyfile': self.keyring.get_password(self.section, 'chef-client-keyfile')
         }
 
     def dockerhub_credentials(self):
         return {
-            'username': self.config.get_param('cirrus', 'docker_login_username', None),
-            'email': self.config.get_param('cirrus', 'docker_login_email', None),
-            'password': self.config.get_param('cirrus', 'docker_login_password', None)
+            'username': self.keyring.get_password(self.section, 'docker_login_username'),
+            'email': self.keyring.get_password(self.section, 'docker_login_email'),
+            'password': self.keyring.get_password(self.section, 'docker_login_password')
         }

--- a/tests/unit/cirrus/configuration_test.py
+++ b/tests/unit/cirrus/configuration_test.py
@@ -8,6 +8,7 @@ import ConfigParser
 import tempfile
 import mock
 
+from cirrus.plugins.creds.default import Default
 from cirrus.configuration import load_configuration
 
 
@@ -20,6 +21,7 @@ class ConfigurationTests(unittest.TestCase):
         """create a sample conf file"""
         self.dir = tempfile.mkdtemp()
         self.test_file = os.path.join(self.dir, 'cirrus.conf')
+        self.gitconfig = os.path.join(self.dir, '.gitconfig')
 
         parser = ConfigParser.RawConfigParser()
         parser.add_section('package')
@@ -33,16 +35,21 @@ class ConfigurationTests(unittest.TestCase):
         with open(self.test_file, 'w') as handle:
             parser.write(handle)
 
+        gitconf = ConfigParser.RawConfigParser()
+        gitconf.add_section('cirrus')
+        gitconf.set('cirrus', 'credential-plugin', 'default')
+        with open(self.gitconfig, 'w') as handle:
+            gitconf.write(handle)
+
     def tearDown(self):
         """cleanup"""
         if os.path.exists(self.dir):
             os.system('rm -rf {0}'.format(self.dir))
 
-
     def test_reading(self):
         """test config load """
         #test read and accessors
-        config = load_configuration(package_dir=self.dir)
+        config = load_configuration(package_dir=self.dir, gitconfig_file=self.gitconfig)
         self.assertEqual(config.package_version(), '1.2.3')
         self.assertEqual(config.package_name(), 'cirrus_tests')
 
@@ -52,6 +59,9 @@ class ConfigurationTests(unittest.TestCase):
 
         self.assertEqual(config.release_notes(), (None, None))
         self.assertEqual(config.version_file(), (None, '__version__'))
+
+        self.failUnless(config.credentials is not None)
+        self.failUnless(isinstance(config.credentials, Default))
 
         # test updating version
         config.update_package_version('1.2.4')
@@ -72,6 +82,7 @@ class ConfigurationTests(unittest.TestCase):
         mock_pop.assert_has_calls(mock.call(['git', 'rev-parse', '--show-toplevel'], stdout=-1))
         self.assertEqual(config.package_version(), '1.2.3')
         self.assertEqual(config.package_name(), 'cirrus_tests')
+
 
 
 if __name__ == '__main__':

--- a/tests/unit/cirrus/configuration_test.py
+++ b/tests/unit/cirrus/configuration_test.py
@@ -69,7 +69,7 @@ class ConfigurationTests(unittest.TestCase):
         config = load_configuration(package_dir="womp")
 
         self.failUnless(mock_result.communicate.called)
-        mock_pop.assert_has_calls(mock.call([['git', 'rev-parse', '--show-toplevel']], stdout=-1))
+        mock_pop.assert_has_calls(mock.call(['git', 'rev-parse', '--show-toplevel'], stdout=-1))
         self.assertEqual(config.package_version(), '1.2.3')
         self.assertEqual(config.package_name(), 'cirrus_tests')
 

--- a/tests/unit/cirrus/creds_plugin_tests.py
+++ b/tests/unit/cirrus/creds_plugin_tests.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""
+creds_plugin tests
+"""
+import unittest
+
+from cirrus.creds_plugin import CredsPlugin
+
+
+class CredsPluginTest(unittest.TestCase):
+    """
+    test coverage for creds plugin object
+    """
+    def test_creds_plugin(self):
+        """test base class methods"""
+        plugin = CredsPlugin()
+        methods = [x[0] for x in plugin.credential_methods()]
+        mapping = plugin.credential_map()
+        self.failUnless(all(m in mapping for m in methods))
+
+        gh_defaults = plugin.github_credentials()
+        self.failUnless('github_user' in gh_defaults)
+        self.failUnless('github_token' in gh_defaults)
+        self.assertEqual(gh_defaults['github_user'], None)
+        self.assertEqual(gh_defaults['github_token'], None)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/cirrus/default_creds_tests.py
+++ b/tests/unit/cirrus/default_creds_tests.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+"""
+tests for default credential manager using gitconfig
+"""
+import os
+import unittest
+import tempfile
+import ConfigParser
+
+from cirrus.plugins.creds.default import Default
+
+
+class DefaultCredsTests(unittest.TestCase):
+    """
+    test default plugin gitconfig access
+    """
+    def setUp(self):
+        """set up a test gitconfig"""
+        self.dir = tempfile.mkdtemp()
+        self.gitconfig = os.path.join(self.dir, '.gitconfig')
+
+        gitconf = ConfigParser.RawConfigParser()
+        gitconf.add_section('cirrus')
+        gitconf.set('cirrus', 'credential-plugin', 'default')
+        gitconf.set('cirrus', 'github-user', 'steve')
+        gitconf.set('cirrus', 'github-token', 'steves token')
+
+        with open(self.gitconfig, 'w') as handle:
+            gitconf.write(handle)
+
+    def tearDown(self):
+        """cleanup"""
+        if os.path.exists(self.dir):
+            os.system('rm -rf {0}'.format(self.dir))
+
+    def test_reading_gitconfig(self):
+        """test reading in the fake gitconfig and accessing data"""
+        plugin = Default(gitconfig_file=self.gitconfig)
+        gh = plugin.github_credentials()
+        self.failUnless('github_user' in gh)
+        self.failUnless('github_token' in gh)
+        self.assertEqual(gh['github_user'], 'steve')
+        self.assertEqual(gh['github_token'], 'steves token')
+
+        # test all the methods work with defaults
+        for n, m in plugin.credential_methods():
+            m()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/cirrus/keyring_creds_tests.py
+++ b/tests/unit/cirrus/keyring_creds_tests.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+"""
+keyring_plugin_tests
+
+Test coverage for the keyring creds plugin
+"""
+
+import unittest
+import mock
+from cirrus.plugins.creds.keyring import Keyring
+
+
+class KeyringCredsTest(unittest.TestCase):
+    """
+    test coverage for keyring creds accessor
+    """
+    @mock.patch('cirrus.plugins.creds.keyring.keyring')
+    def test_keyring_plugin(self, mock_keyring):
+        """test keyring plugin with mocked values for gh creds"""
+        mock_instance = mock.Mock()
+        mock_instance.get_password = mock.Mock()
+        mock_instance.get_password.side_effect = ['steve', 'steves token']
+        mock_keyring.get_keyring = mock.Mock()
+        mock_keyring.get_keyring.return_value = mock_instance
+
+        plugin = Keyring()
+
+        gh = plugin.github_credentials()
+        self.failUnless('github_user' in gh)
+        self.failUnless('github_token' in gh)
+        self.assertEqual(gh['github_user'], 'steve')
+        self.assertEqual(gh['github_token'], 'steves token')
+
+    @mock.patch('cirrus.plugins.creds.keyring.keyring')
+    def test_all_methods(self, mock_keyring):
+        """test coverage for all methods"""
+        mock_instance = mock.Mock()
+        mock_instance.get_password = mock.Mock()
+        mock_instance.get_password.return_value = 'womp'
+        mock_keyring.get_keyring = mock.Mock()
+        mock_keyring.get_keyring.return_value = mock_instance
+        # test all the methods work with defaults
+        plugin = Keyring()
+        for n, m in plugin.credential_methods():
+            check = m()
+            self.failUnless(all(v is 'womp' for v in check.values()))
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This feature refactors the auth/cred getting code (currently a few methods scattered in the configuration module) into a backend plugin with two implementations: 
- gitconfig (The current model) 
- keyring (New, uses the platform password store, eg Keychain on MacOSX) 

The goal of this is to standardise the auth config so that it is easier to make available to templating operations in commands and also offer a more secure solution than a password in a file that we currently have. 