### PR TITLE
Feature/cirrus settings context

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ keyring==8.5.1
 virtualenv
 ./venv/cache/gitconfig-0.0.2.tar.gz
 pluggage
-dockerstache
+dockerstache>=0.0.9

--- a/src/cirrus/configuration.py
+++ b/src/cirrus/configuration.py
@@ -38,8 +38,8 @@ class Configuration(dict):
     """
     def __init__(self, config_file, gitconfig_file=None):
         super(Configuration, self).__init__(self)
-        self.config_file = config_file
         self.gitconfig_file = gitconfig_file
+        self.config_file = config_file
         self.parser = None
         self.credentials = None
         self.gitconfig = None
@@ -162,6 +162,15 @@ class Configuration(dict):
         with open(self.config_file, 'w') as handle:
             self.parser.write(handle)
 
+    def configuration_map(self):
+        result = {
+            "cirrus": {
+                "configuration": dict(self),
+                "credentials": self.credentials.credential_map()
+            }
+        }
+        return result
+
 
 def _repo_directory():
     command = ['git', 'rev-parse', '--show-toplevel']
@@ -269,4 +278,4 @@ def get_chef_auth():
 
 
 if __name__ == '__main__':
-    load_configuration()
+    c = load_configuration()

--- a/src/cirrus/docker.py
+++ b/src/cirrus/docker.py
@@ -256,7 +256,8 @@ def docker_build(opts, config):
             input=templ,
             output=path,
             context=helper['context'],
-            defaults=helper['defaults']
+            defaults=helper['defaults'],
+            extend_context=config.configuration_map()
         )
 
     image = _docker_build(path, tag, tag_base(config))

--- a/tests/unit/cirrus/configuration_test.py
+++ b/tests/unit/cirrus/configuration_test.py
@@ -41,8 +41,15 @@ class ConfigurationTests(unittest.TestCase):
         with open(self.gitconfig, 'w') as handle:
             gitconf.write(handle)
 
+        self.patcher = mock.patch('cirrus.plugins.creds.default.os')
+        default_os = self.patcher.start()
+        default_os.path = mock.Mock()
+        default_os.path.join = mock.Mock()
+        default_os.path.join.return_value = self.gitconfig
+
     def tearDown(self):
         """cleanup"""
+        self.patcher.stop()
         if os.path.exists(self.dir):
             os.system('rm -rf {0}'.format(self.dir))
 
@@ -82,6 +89,20 @@ class ConfigurationTests(unittest.TestCase):
         mock_pop.assert_has_calls(mock.call(['git', 'rev-parse', '--show-toplevel'], stdout=-1))
         self.assertEqual(config.package_version(), '1.2.3')
         self.assertEqual(config.package_name(), 'cirrus_tests')
+
+    def test_configuration_map(self):
+        """test building config mapping"""
+        config = load_configuration(package_dir=self.dir, gitconfig_file=self.gitconfig)
+        mapping = config.configuration_map()
+        self.failUnless('cirrus' in mapping)
+        self.failUnless('credentials' in mapping['cirrus'])
+        self.failUnless('configuration' in mapping['cirrus'])
+        self.failUnless('github_credentials' in mapping['cirrus']['credentials'])
+        self.assertEqual(
+            mapping['cirrus']['credentials']['github_credentials'],
+            {'github_user': None, 'github_token': None}
+        )
+
 
 
 

--- a/tests/unit/cirrus/configuration_test.py
+++ b/tests/unit/cirrus/configuration_test.py
@@ -102,7 +102,9 @@ class ConfigurationTests(unittest.TestCase):
             mapping['cirrus']['credentials']['github_credentials'],
             {'github_user': None, 'github_token': None}
         )
-
+        self.assertEqual(
+            mapping['cirrus']['configuration']['package']['name'], 'cirrus_tests'
+        )
 
 
 

--- a/tests/unit/cirrus/docker_test.py
+++ b/tests/unit/cirrus/docker_test.py
@@ -45,6 +45,12 @@ class DockerFunctionTests(unittest.TestCase):
             'repo': 'unittesting'
 
         }
+        self.config.credentials = mock.Mock()
+        self.config.credentials.credential_map = mock.Mock()
+        self.config.credentials.credential_map.return_value = {
+            'github_credentials': {'github_user': 'steve', 'github_token': 'steves gh token'},
+            'pypi_credentials': {'username': 'steve', 'token': 'steves pypi token'}
+        }
 
     def tearDown(self):
         self.patcher.stop()
@@ -71,7 +77,7 @@ class DockerFunctionTests(unittest.TestCase):
 
         mock_ds.run.assert_has_calls(
             mock.call(
-                output='vm/docker_image', context=None, defaults=None, input='template'
+                output='vm/docker_image', context=None, defaults=None, input='template', extend_context=mock.ANY
             )
         )
         self.mock_subp.check_output.assert_has_calls(


### PR DESCRIPTION
This PR includes the cirrus config and credentials in calls to the dockerstache templating engine so that cirrus params can be referenced in templates without having to drop them in intermediate files

@petevg 