### PR TITLE
Feature/selfupdate updates venv

### DIFF
--- a/src/cirrus/build.py
+++ b/src/cirrus/build.py
@@ -45,7 +45,6 @@ def build_parser(argslist):
         nargs='*',
         help='generate documentation with Sphinx (Makefile path must be set in cirrus.conf.')
 
-    opts = parser.parse_args(argslist)
     parser.add_argument(
         '-u',
         '--upgrade',
@@ -53,6 +52,7 @@ def build_parser(argslist):
         default=False,
         help='Use --upgrade to update the dependencies in the package requirements'
     )
+    opts = parser.parse_args(argslist)
     return opts
 
 

--- a/src/cirrus/build.py
+++ b/src/cirrus/build.py
@@ -46,6 +46,13 @@ def build_parser(argslist):
         help='generate documentation with Sphinx (Makefile path must be set in cirrus.conf.')
 
     opts = parser.parse_args(argslist)
+    parser.add_argument(
+        '-u',
+        '--upgrade',
+        action='store_true',
+        default=False,
+        help='Use --upgrade to update the dependencies in the package requirements'
+    )
     return opts
 
 
@@ -87,7 +94,7 @@ def execute_build(opts):
         local(cmd)
 
     if not os.path.exists(venv_bin_path):
-        cmd = "{0} --distribute {1}".format(venv_command, venv_path)
+        cmd = "{0} {1}".format(venv_command, venv_path)
         LOGGER.info("Bootstrapping virtualenv: {0}".format(venv_path))
         local(cmd)
 
@@ -100,16 +107,25 @@ def execute_build(opts):
             pypi_username=pypi_conf['username'],
             pypi_server=pypi_server
         )
-
-        cmd = (
-            '{0}/bin/pip install '
-            "-i {1} "
-            '-r {2}'
-            ).format(venv_path, pypi_url, reqs_name)
+        if opts.upgrade:
+            cmd = (
+                '{0}/bin/pip install --upgrade '
+                "-i {1} "
+                '-r {2}'
+                ).format(venv_path, pypi_url, reqs_name)
+        else:
+            cmd = (
+                '{0}/bin/pip install '
+                "-i {1} "
+                '-r {2}'
+                ).format(venv_path, pypi_url, reqs_name)
 
     else:
         # no pypi server
-        cmd = '{0}/bin/pip install -r {1}'.format(venv_path, reqs_name)
+        if opts.upgrade:
+            cmd = '{0}/bin/pip install --upgrade -r {1}'.format(venv_path, reqs_name)
+        else:
+            cmd = '{0}/bin/pip install -r {1}'.format(venv_path, reqs_name)
 
     try:
         local(cmd)

--- a/src/cirrus/selfupdate.py
+++ b/src/cirrus/selfupdate.py
@@ -112,7 +112,6 @@ def find_cirrus_install():
     return cirrus_dir
 
 
-
 def setup_develop(config):
     """
     _setup_develop_
@@ -122,7 +121,7 @@ def setup_develop(config):
     """
     LOGGER.info("running setup.py develop...")
     local(
-        'git cirrus build'
+        'git cirrus build --upgrade'
     )
 
     local(


### PR DESCRIPTION
Adds --upgrade to build command to allow build to update any dependencies in the requirements file via pip install --upgrade. 
Add the upgrade flag in the git cirrus build called by selfupdate

Addresses:
https://github.com/evansde77/cirrus/issues/98