### PR TITLE
Feature/update gitpython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ argparse==1.2.1
 arrow==0.4.2
 distribute==0.7.3
 Fabric==1.9.0
-GitPython==0.3.2.RC1
+GitPython==0.3.5
 mock==1.0.1
 nose==1.3.0
 pep8==1.5.7

--- a/src/cirrus/release.py
+++ b/src/cirrus/release.py
@@ -15,7 +15,7 @@ from fabric.operations import local
 import pluggage.registry
 
 from argparse import ArgumentParser
-from cirrus.configuration import load_configuration
+from cirrus.configuration import load_configuration, _repo_directory
 from cirrus.git_tools import build_release_notes
 from cirrus.git_tools import has_unstaged_changes
 from cirrus.git_tools import branch, checkout_and_pull
@@ -388,7 +388,7 @@ def new_release(opts):
     LOGGER.info('release branch is {0}'.format(branch_name))
 
     # need to be on the latest develop
-    repo_dir = os.getcwd()
+    repo_dir = _repo_directory()
     # make sure the branch doesnt already exist on remote
     if remote_branch_exists(repo_dir, branch_name):
         msg = (

--- a/tests/unit/cirrus/github_tools_test.py
+++ b/tests/unit/cirrus/github_tools_test.py
@@ -4,11 +4,12 @@ tests for github_tools
 import json
 import mock
 import unittest
+import subprocess
 
 from cirrus.github_tools import create_pull_request
 from cirrus.github_tools import current_branch_mark_status
 from cirrus.github_tools import get_releases
-
+from .harnesses import _repo_directory
 
 class GithubToolsTest(unittest.TestCase):
     """
@@ -110,7 +111,7 @@ class GithubToolsTest(unittest.TestCase):
         mock_config_load.organisation_name.return_value = self.owner
         mock_config_load.package_name.return_value = self.repo
 
-        current_branch_mark_status(".", "success")
+        current_branch_mark_status(_repo_directory(), "success")
 
         self.failUnless(mock_post.called)
 

--- a/tests/unit/cirrus/harnesses.py
+++ b/tests/unit/cirrus/harnesses.py
@@ -11,9 +11,17 @@ import os
 import unittest
 import tempfile
 import mock
+import subprocess
 import ConfigParser
 
 from cirrus.configuration import Configuration
+
+
+def _repo_directory():
+    command = ['git', 'rev-parse', '--show-toplevel']
+    process = subprocess.Popen(command, stdout=subprocess.PIPE)
+    outp, err = process.communicate()
+    return outp.strip()
 
 
 def write_cirrus_conf(config_file, **sections):

--- a/tests/unit/cirrus/release_test.py
+++ b/tests/unit/cirrus/release_test.py
@@ -15,7 +15,7 @@ from cirrus.release import artifact_name
 from cirrus.configuration import Configuration
 from pluggage.errors import FactoryError
 
-from harnesses import CirrusConfigurationHarness, write_cirrus_conf
+from harnesses import CirrusConfigurationHarness, write_cirrus_conf, _repo_directory
 
 class ReleaseNewCommandTest(unittest.TestCase):
     """


### PR DESCRIPTION

Based on some research it seems 
https://github.com/evansde77/cirrus/issues/32
may be caused by an outdated GitPython, so this PR updates GitPython to 3.5 and as a result a couple 
of tests needed tweaked to use the actual git repo dir during tests as well. 
This also exposed an issue with the release command where it defaulted to pwd instead of the repo dir, so that got fixed here as well. 

@jcounts @petevg @ksnavely 
