### PR TITLE
Feature/cleanup repo directory

### DIFF
--- a/src/cirrus/configuration.py
+++ b/src/cirrus/configuration.py
@@ -13,9 +13,11 @@ conf = load_configuration()
 """
 import os
 from cirrus.gitconfig import load_gitconfig
+from cirrus.environment import repo_directory
 import subprocess
 import ConfigParser
 import pluggage.registry
+
 
 
 def get_creds_plugin(plugin_name):
@@ -202,13 +204,6 @@ class Configuration(dict):
         return result
 
 
-def _repo_directory():
-    command = ['git', 'rev-parse', '--show-toplevel']
-    process = subprocess.Popen(command, stdout=subprocess.PIPE)
-    outp, err = process.communicate()
-    return outp.strip()
-
-
 def load_configuration(package_dir=None, gitconfig_file=None):
     """
     _load_configuration_
@@ -227,8 +222,9 @@ def load_configuration(package_dir=None, gitconfig_file=None):
 
     config_path = os.path.join(dirname, 'cirrus.conf')
     if not os.path.exists(config_path):
-        repo_dir = _repo_directory()
-        config_path = os.path.join(repo_dir, 'cirrus.conf')
+        repo_dir = repo_directory()
+        if repo_dir is not None:
+            config_path = os.path.join(repo_dir, 'cirrus.conf')
 
     if not os.path.exists(config_path):
         msg = "Couldnt find ./cirrus.conf, are you in a package directory?"

--- a/src/cirrus/configuration.py
+++ b/src/cirrus/configuration.py
@@ -19,7 +19,6 @@ import ConfigParser
 import pluggage.registry
 
 
-
 def get_creds_plugin(plugin_name):
     """
     _get_creds_plugin_
@@ -95,7 +94,9 @@ class Configuration(dict):
         """helper to read values from users .gitconfig"""
         return self.gitconfig.get_param(section, param)
 
-    def has_gitconfig_param(self, param, section='cirrus', validator=lambda x: x is not None):
+    def has_gitconfig_param(
+            self, param, section='cirrus', validator=lambda x: x is not None
+            ):
         """helper to check if a gitconfig param is set/present"""
         if not param in self.list_gitconfig_params(section):
             return False

--- a/src/cirrus/environment.py
+++ b/src/cirrus/environment.py
@@ -16,14 +16,14 @@ import subprocess
 #
 # number of subdirectories from cirrus/__init__.py
 # when installed in a venv under CIRRUS_HOME location
-NUMBER_OF_SUBDIRS=6
+NUMBER_OF_SUBDIRS = 6
 
 
 def repo_directory():
     """
-    helper method that extracts the current git repo directory 
-    using a callout to git rev-parse. 
-    If in a repo, this returns the path to the top level dir, 
+    helper method that extracts the current git repo directory
+    using a callout to git rev-parse.
+    If in a repo, this returns the path to the top level dir,
     if not, it returns None
     """
     command = ['git', 'rev-parse', '--show-toplevel']
@@ -44,13 +44,12 @@ def cirrus_home():
     """
     if os.environ.get('CIRRUS_HOME') is not None:
         return os.environ['CIRRUS_HOME']
-    
     home = inspect.getsourcefile(cirrus)
     if ('lib' in home) and ('site-packages' in home):
         # we are in a pip installed virtualenv site-packages
         # from the cirrus init py in the venv, we need to
         # move up 5 dirs to get the install directory
-        for _ in range(NUMBER_OF_SUBDIRS): 
+        for _ in range(NUMBER_OF_SUBDIRS):
             home = os.path.dirname(home)
     else:
         # we are in a local git repo
@@ -61,6 +60,7 @@ def cirrus_home():
             raise RuntimeError(msg)
     os.environ['CIRRUS_HOME'] = home
     return home
+
 
 def virtualenv_home():
     """

--- a/src/cirrus/environment.py
+++ b/src/cirrus/environment.py
@@ -13,7 +13,19 @@ import posixpath
 import subprocess
 
 
+#
+# number of subdirectories from cirrus/__init__.py
+# when installed in a venv under CIRRUS_HOME location
+NUMBER_OF_SUBDIRS=6
+
+
 def repo_directory():
+    """
+    helper method that extracts the current git repo directory 
+    using a callout to git rev-parse. 
+    If in a repo, this returns the path to the top level dir, 
+    if not, it returns None
+    """
     command = ['git', 'rev-parse', '--show-toplevel']
     process = subprocess.Popen(command, stdout=subprocess.PIPE)
     outp, err = process.communicate()
@@ -34,11 +46,11 @@ def cirrus_home():
         return os.environ['CIRRUS_HOME']
     
     home = inspect.getsourcefile(cirrus)
-    if ('venv' in home) and ('site-packages' in home):
+    if ('lib' in home) and ('site-packages' in home):
         # we are in a pip installed virtualenv site-packages
         # from the cirrus init py in the venv, we need to
         # move up 5 dirs to get the install directory
-        for i in range(6): 
+        for _ in range(NUMBER_OF_SUBDIRS): 
             home = os.path.dirname(home)
     else:
         # we are in a local git repo

--- a/src/cirrus/environment.py
+++ b/src/cirrus/environment.py
@@ -34,7 +34,7 @@ def cirrus_home():
         return os.environ['CIRRUS_HOME']
     
     home = inspect.getsourcefile(cirrus)
-    if 'venv' in home and 'site-packages' in home:
+    if ('venv' in home) and ('site-packages' in home):
         # we are in a pip installed virtualenv site-packages
         # from the cirrus init py in the venv, we need to
         # move up 5 dirs to get the install directory
@@ -48,7 +48,7 @@ def cirrus_home():
             msg = "Unable to determine cirrus install location"
             raise RuntimeError(msg)
     os.environ['CIRRUS_HOME'] = home
-    return os.environ['CIRRUS_HOME']
+    return home
 
 def virtualenv_home():
     """

--- a/src/cirrus/release.py
+++ b/src/cirrus/release.py
@@ -15,7 +15,8 @@ from fabric.operations import local
 import pluggage.registry
 
 from argparse import ArgumentParser
-from cirrus.configuration import load_configuration, _repo_directory
+from cirrus.configuration import load_configuration
+from cirrus.environment import repo_directory
 from cirrus.git_tools import build_release_notes
 from cirrus.git_tools import has_unstaged_changes
 from cirrus.git_tools import branch, checkout_and_pull
@@ -388,7 +389,7 @@ def new_release(opts):
     LOGGER.info('release branch is {0}'.format(branch_name))
 
     # need to be on the latest develop
-    repo_dir = _repo_directory()
+    repo_dir = repo_directory()
     # make sure the branch doesnt already exist on remote
     if remote_branch_exists(repo_dir, branch_name):
         msg = (

--- a/tests/unit/cirrus/configuration_test.py
+++ b/tests/unit/cirrus/configuration_test.py
@@ -86,6 +86,7 @@ class ConfigurationTests(unittest.TestCase):
         """test config load using repo dir"""
         mock_result = mock.Mock()
         mock_result.communicate = mock.Mock()
+        mock_result.returncode = 0
         mock_result.communicate.return_value = (self.dir, None)
         mock_pop.return_value = mock_result
         mock_shell.return_value = self.gitconf_str

--- a/tests/unit/cirrus/environment_test.py
+++ b/tests/unit/cirrus/environment_test.py
@@ -49,7 +49,7 @@ class EnvironmentFunctionTests(unittest.TestCase):
         del os.environ['VIRTUALENV_HOME']
 
         home2 = virtualenv_home()
-        self.assertEqual(home2, 'TESTVALUE/cirrus/venv')
+        self.assertEqual(home2, 'TESTVALUE/venv')
 
 
 if __name__ == '__main__':

--- a/tests/unit/cirrus/environment_test.py
+++ b/tests/unit/cirrus/environment_test.py
@@ -7,7 +7,7 @@ unittests for cirrus.environment module
 import os
 import copy
 import unittest
-import mock 
+import mock
 import tempfile
 
 from cirrus.environment import cirrus_home
@@ -22,17 +22,17 @@ class EnvironmentFunctionTests(unittest.TestCase):
     def setUp(self):
         """save/mock the os.environ settings"""
         self.cirrus_home = copy.deepcopy(os.environ.get('CIRRUS_HOME'))
-        self.venv_home =  copy.deepcopy(os.environ.get('VIRTUALENV_HOME'))
+        self.venv_home = copy.deepcopy(os.environ.get('VIRTUALENV_HOME'))
         os.environ['CIRRUS_HOME'] = "TESTVALUE"
         os.environ['VIRTUALENV_HOME'] = "TESTVALUE"
-       
+
     def tearDown(self):
         """reset env vars"""
-        if  self.cirrus_home is not None:
+        if self.cirrus_home is not None:
             os.environ['CIRRUS_HOME'] = self.cirrus_home
         if self.venv_home is not None:
             os.environ['VIRTUALENV_HOME'] = self.venv_home
-       
+
     def test_cirrus_home(self):
         """test cirrus home function"""
 
@@ -59,10 +59,10 @@ class CleanEnvironmentTests(unittest.TestCase):
         """save/mock the os.environ settings"""
         self.dir = tempfile.mkdtemp()
         self.venv_dir = os.path.join(
-            self.dir, 'venv', 'lib', 'python2.7', 
+            self.dir, 'venv', 'lib', 'python2.7',
             'site-packages', 'cirrus', '__init__.py'
             )
-        self.venv_dir_2 =  os.path.join(
+        self.venv_dir_2 = os.path.join(
             self.dir, 'venv', 'cirrus', '__init__.py'
             )
 
@@ -97,7 +97,7 @@ class CleanEnvironmentTests(unittest.TestCase):
         mock_env.__getitem__ = mock.Mock()
         mock_env.__getitem__.return_value = self.dir
         mock_env.__setitem__ = mock.Mock()
-        mock_srcfile.return_value = self.venv_dir_2 
+        mock_srcfile.return_value = self.venv_dir_2
         mock_repo.return_value = None
         self.assertRaises(RuntimeError, cirrus_home)
         self.failUnless(not mock_env.__setitem__.called)
@@ -112,7 +112,7 @@ class CleanEnvironmentTests(unittest.TestCase):
         mock_env.__getitem__ = mock.Mock()
         mock_env.__getitem__.return_value = None
         mock_env.__setitem__ = mock.Mock()
-        mock_srcfile.return_value = self.venv_dir_2 
+        mock_srcfile.return_value = self.venv_dir_2
         mock_repo.return_value = os.path.dirname(self.venv_dir_2)
         self.assertEqual(cirrus_home(), os.path.dirname(self.venv_dir_2))
         self.failUnless(mock_repo.called)
@@ -121,5 +121,3 @@ class CleanEnvironmentTests(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
-

--- a/tests/unit/cirrus/environment_test.py
+++ b/tests/unit/cirrus/environment_test.py
@@ -7,9 +7,12 @@ unittests for cirrus.environment module
 import os
 import copy
 import unittest
+import mock 
+import tempfile
 
 from cirrus.environment import cirrus_home
 from cirrus.environment import virtualenv_home
+
 
 class EnvironmentFunctionTests(unittest.TestCase):
     """
@@ -20,18 +23,16 @@ class EnvironmentFunctionTests(unittest.TestCase):
         """save/mock the os.environ settings"""
         self.cirrus_home = copy.deepcopy(os.environ.get('CIRRUS_HOME'))
         self.venv_home =  copy.deepcopy(os.environ.get('VIRTUALENV_HOME'))
-
-
         os.environ['CIRRUS_HOME'] = "TESTVALUE"
         os.environ['VIRTUALENV_HOME'] = "TESTVALUE"
-
+       
     def tearDown(self):
         """reset env vars"""
         if  self.cirrus_home is not None:
             os.environ['CIRRUS_HOME'] = self.cirrus_home
         if self.venv_home is not None:
             os.environ['VIRTUALENV_HOME'] = self.venv_home
-
+       
     def test_cirrus_home(self):
         """test cirrus home function"""
 
@@ -50,6 +51,72 @@ class EnvironmentFunctionTests(unittest.TestCase):
 
         home2 = virtualenv_home()
         self.assertEqual(home2, 'TESTVALUE/venv')
+
+
+class CleanEnvironmentTests(unittest.TestCase):
+
+    def setUp(self):
+        """save/mock the os.environ settings"""
+        self.dir = tempfile.mkdtemp()
+        self.venv_dir = os.path.join(
+            self.dir, 'venv', 'lib', 'python2.7', 
+            'site-packages', 'cirrus', '__init__.py'
+            )
+        self.venv_dir_2 =  os.path.join(
+            self.dir, 'venv', 'cirrus', '__init__.py'
+            )
+
+    def tearDown(self):
+        """reset env vars"""
+        if os.path.exists(self.dir):
+            os.system('rm -rf {}'.format(self.dir))
+
+    @mock.patch('cirrus.environment.inspect.getsourcefile')
+    @mock.patch('cirrus.environment.repo_directory')
+    @mock.patch('cirrus.environment.os.environ')
+    def test_cirrus_home_in_venv(self, mock_env, mock_repo, mock_srcfile):
+        mock_env.get = mock.Mock()
+        mock_env.get = mock.Mock()
+        mock_env.get.return_value = None
+        mock_env.__getitem__ = mock.Mock()
+        mock_env.__getitem__.return_value = self.dir
+        mock_env.__setitem__ = mock.Mock()
+        mock_srcfile.return_value = self.venv_dir
+        self.assertEqual(cirrus_home(), self.dir)
+        self.failUnless(not mock_repo.called)
+        self.failUnless(mock_env.__setitem__.called)
+
+    @mock.patch('cirrus.environment.inspect.getsourcefile')
+    @mock.patch('cirrus.environment.repo_directory')
+    @mock.patch('cirrus.environment.os.environ')
+    def test_cirrus_home_in_bad_repo(self, mock_env, mock_repo, mock_srcfile):
+        """test no venv or repo"""
+        mock_env.get = mock.Mock()
+        mock_env.get = mock.Mock()
+        mock_env.get.return_value = None
+        mock_env.__getitem__ = mock.Mock()
+        mock_env.__getitem__.return_value = self.dir
+        mock_env.__setitem__ = mock.Mock()
+        mock_srcfile.return_value = self.venv_dir_2 
+        mock_repo.return_value = None
+        self.assertRaises(RuntimeError, cirrus_home)
+        self.failUnless(not mock_env.__setitem__.called)
+
+    @mock.patch('cirrus.environment.inspect.getsourcefile')
+    @mock.patch('cirrus.environment.repo_directory')
+    @mock.patch('cirrus.environment.os.environ')
+    def test_cirrus_home_in_repo(self, mock_env, mock_repo, mock_srcfile):
+        """test repo source file and no repo info"""
+        mock_env.get = mock.Mock()
+        mock_env.get.return_value = None
+        mock_env.__getitem__ = mock.Mock()
+        mock_env.__getitem__.return_value = None
+        mock_env.__setitem__ = mock.Mock()
+        mock_srcfile.return_value = self.venv_dir_2 
+        mock_repo.return_value = os.path.dirname(self.venv_dir_2)
+        self.assertEqual(cirrus_home(), os.path.dirname(self.venv_dir_2))
+        self.failUnless(mock_repo.called)
+        self.failUnless(mock_env.__setitem__.called)
 
 
 if __name__ == '__main__':

--- a/tests/unit/cirrus/release_test.py
+++ b/tests/unit/cirrus/release_test.py
@@ -15,7 +15,8 @@ from cirrus.release import artifact_name
 from cirrus.configuration import Configuration
 from pluggage.errors import FactoryError
 
-from harnesses import CirrusConfigurationHarness, write_cirrus_conf, _repo_directory
+from harnesses import CirrusConfigurationHarness, write_cirrus_conf
+
 
 class ReleaseNewCommandTest(unittest.TestCase):
     """


### PR DESCRIPTION
Further cleanup from migration to pip installer. 

- Make environment lookup more flexible and better test coverage
- rename repo_directory as public method and move it to a lower level, refactor around that and update tests as needed 

@ksnavely @shudgston @appeltel @PerilousApricot
