### PR TITLE
Fix readme and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Installation as a user:
 =======================
 
 ```bash
-curl -O https://raw.githubusercontent.com/evansde77/cirrus/develop/installer2.sh
-bash installer2.sh
+curl -O https://raw.githubusercontent.com/evansde77/cirrus/develop/installer.sh
+bash installer.sh
 ```
 
 The installer script will set up an install of cirrus for you in your home directory
@@ -28,6 +28,7 @@ pull requests made against develop, not master.
 
 ```bash
 git clone https://github.com/evansde77/cirrus.git
+cd cirrus
 git cirrus build
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 argparse==1.2.1
 arrow==0.4.2
-Fabric==1.9.0
+Fabric==1.11.1
 GitPython==0.3.5
 mock==1.0.1
 nose==1.3.0
@@ -12,4 +12,3 @@ keyring==8.5.1
 virtualenv
 pluggage
 dockerstache>=0.0.9
-pycrypto==2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ keyring==8.5.1
 virtualenv
 pluggage
 dockerstache>=0.0.9
+pycrypto==2.6


### PR DESCRIPTION
Fix the installation instructions to reflect the fact that installer2.sh no longer exists, and add a cd step to the development install in case its not obvious to everyone.

For some reason unit tests were failing both for my environment and travis as Fabric couldn't find the pycrypto package, so I added it as a dependency to fix.

@evansde77