### PR TITLE
Feature/docker push latest tag

### DIFF
--- a/src/cirrus/docker.py
+++ b/src/cirrus/docker.py
@@ -85,7 +85,7 @@ def build_parser():
         '--login',
         action='store_true',
         dest='login',
-        help='Perform docker login before command using settings in cirrus.conf',
+        help='perform docker login before command using settings in cirrus.conf',
         default=False
     )
     build_command.add_argument(
@@ -118,8 +118,14 @@ def build_parser():
         '--login',
         action='store_true',
         dest='login',
-        help='Perform docker login before command using settings in cirrus.conf',
+        help='perform docker login before command using settings in cirrus.conf',
         default=False
+    )
+    push_command.add_argument(
+        '--latest',
+        action='store_true',
+        dest='latest',
+        help='include the image tagged "latest" in the docker push command'
     )
 
     subparsers.add_parser('test', help='test docker connection')
@@ -271,15 +277,22 @@ def docker_push(opts, config):
     """
     helper = OptionHelper(opts, config)
     if helper['login']:
-        check = _docker_login(helper)
-        if not check:
+        if not _docker_login(helper):
             msg = "Unable to perform docker login due to missing cirrus conf entries"
             LOGGER.error(msg)
             sys.exit(1)
+
     tag = helper['tag']
     if tag is None:
         tag = tag_name(config)
-    _docker_push(tag)
+
+    push_tags = [tag]
+
+    if opts.latest:
+        push_tags.append(latest_tag_name(config))
+
+    for tag in push_tags:
+        _docker_push(tag)
 
 
 def is_docker_connected():

--- a/src/cirrus/docker.py
+++ b/src/cirrus/docker.py
@@ -26,7 +26,9 @@ and you have sufficient privileges to connect.
 
 
 class OptionHelper(dict):
+
     """helper class to resolve cli and cirrus conf opts"""
+
     def __init__(self, cli_opts, config):
         super(OptionHelper, self).__init__()
         self['username'] = config.get_param('docker', 'docker_login_username', None)
@@ -35,17 +37,15 @@ class OptionHelper(dict):
         self['login'] = config.get_param(
             'docker', 'docker_login_username', None
         ) is not None
-        self['tag'] = None
 
         if cli_opts.login:
             self['login'] = True
-        if hasattr(cli_opts, 'tag'):
-            if cli_opts.tag:
-                self['tag'] = cli_opts.tag
 
 
 class BuildOptionHelper(OptionHelper):
+
     """helper class to resolve cli and cirrus conf opts for build"""
+
     def __init__(self, cli_opts, config):
         super(BuildOptionHelper, self).__init__(cli_opts, config)
         self['docker_repo'] = config.get_param('docker', 'repo', None)
@@ -65,7 +65,7 @@ def build_parser():
     """
     _build_parser_
 
-    Set up command line parser for the deploy command
+    Set up command line parser for the docker-image command
 
     """
     parser = ArgumentParser(
@@ -283,17 +283,11 @@ def docker_push(opts, config):
             LOGGER.error(msg)
             sys.exit(1)
 
-    tag = helper['tag']
-    if tag is None:
-        tag = tag_name(config)
-
-    push_tags = [tag]
+    tag = tag_name(config)
+    _docker_push(tag)
 
     if opts.latest:
-        push_tags.append(latest_tag_name(config))
-
-    for tag in push_tags:
-        _docker_push(tag)
+        _docker_push(latest_tag_name(config))
 
 
 def is_docker_connected():

--- a/src/cirrus/docker.py
+++ b/src/cirrus/docker.py
@@ -125,7 +125,8 @@ def build_parser():
         '--latest',
         action='store_true',
         dest='latest',
-        help='include the image tagged "latest" in the docker push command'
+        help='include the image tagged "latest" in the docker push command',
+        default=False
     )
 
     subparsers.add_parser('test', help='test docker connection')

--- a/tests/unit/cirrus/docker_test.py
+++ b/tests/unit/cirrus/docker_test.py
@@ -108,15 +108,25 @@ class DockerFunctionTests(unittest.TestCase):
     def test_docker_push(self):
         """test plain docker push"""
         self.opts.tag = None
-        dckr.docker_push(self.opts, self.config)
-
-        self.opts.tag = "herpderp"
+        self.opts.latest = False
         dckr.docker_push(self.opts, self.config)
 
         self.mock_subp.check_output.assert_has_calls(
             [
                 mock.call(['docker', 'push', 'unittesting/unittesting:1.2.3']),
-                mock.call(['docker', 'push', 'herpderp'])
+            ]
+        )
+
+    def test_docker_push_latest(self):
+        """test plain docker push"""
+        self.opts.tag = None
+        self.opts.latest = True
+        dckr.docker_push(self.opts, self.config)
+
+        self.mock_subp.check_output.assert_has_calls(
+            [
+                mock.call(['docker', 'push', 'unittesting/unittesting:1.2.3']),
+                mock.call(['docker', 'push', 'unittesting/unittesting:latest']),
             ]
         )
 


### PR DESCRIPTION
Adds --latest option to docker-image push command.

* The --latest option (cirrus docker-image push --latest) will cause the
image tagged as "latest" to be pushed to the docker registry in addition
to the image tagged with an explicit version number.
* The current behavior is to only push the image tagged with an explicit
version number (imageName/0.0.0).
* Also, "tag" was removed from the OptionHelper classes since there is no way to
pass a tag option as a command line argument.