### PR TITLE
tweak test command to support tox as well as nose

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ virtualenv
 pluggage
 dockerstache>=0.0.9
 requests-toolbelt==0.6.2
+tox

--- a/src/cirrus/configuration.py
+++ b/src/cirrus/configuration.py
@@ -156,6 +156,9 @@ class Configuration(dict):
     def test_where(self, suite):
         return self.get('test-{0}'.format(suite), {}).get('where')
 
+    def test_mode(self, suite):
+        return self.get('test-{0}'.format(suite), {}).get('mode')
+
     def venv_name(self):
         return self.get('build', {}).get('virtualenv_name', 'venv')
 

--- a/src/cirrus/test.py
+++ b/src/cirrus/test.py
@@ -7,7 +7,6 @@ import sys
 
 from fabric.operations import local
 from argparse import ArgumentParser
-from nose.tools import nottest
 
 from cirrus.configuration import load_configuration
 
@@ -26,7 +25,10 @@ def build_parser(argslist):
     test_command = subparsers.add_parser('test')
     test_command.add_argument(
         '--suite',
-        help='test suite configuration to use as defined in the test-<suite> section of cirrus.conf',
+        help=(
+            'test suite configuration to use as defined in the '
+            'test-<suite> section of cirrus.conf'
+        ),
         default='default'
     )
     test_command.add_argument(
@@ -87,17 +89,17 @@ def main():
     config = load_configuration()
     mode = config.test_mode(opts.suite)
     if opts.mode:
-        mode =  opts.mode
+        mode = opts.mode
 
     # backwards compat: default to nosetests
     if mode is None:
         mode = 'nosetests'
 
     if mode == 'nosetests':
-        nose_test(config, opts)
+        nose_run(config, opts)
         sys.exit(0)
     if mode == 'tox':
-        tox_test(config, opts)
+        tox_run(config, opts)
         sys.exit(0)
 
 

--- a/src/cirrus/test.py
+++ b/src/cirrus/test.py
@@ -22,24 +22,60 @@ def build_parser(argslist):
     parser = ArgumentParser(
         description='git cirrus test command'
     )
-    parser.add_argument('test', nargs='+')
-    parser.add_argument('--suite') 
+    subparsers = parser.add_subparsers(dest='command')
+    test_command = subparsers.add_parser('test')
+    test_command.add_argument(
+        '--suite',
+        help='test suite configuration to use as defined in the test-<suite> section of cirrus.conf',
+        default='default'
+    )
+    test_command.add_argument(
+        '--mode',
+        choices=['nosetests', 'tox'],
+        default=None,
+        help='Choose test runner framework'
+    )
+    test_command.add_argument(
+        '--test-options',
+        default='',
+        dest='options',
+        help='Optional args to pass to test runner'
+    )
 
     opts = parser.parse_args(argslist)
     return opts
 
 
 @nottest
-def nose_test(location):
+def nose_test(config, opts):
     """
     _nose_test_
 
-    Locally activate vitrualenv and run tests
+    Locally activate vitrualenv and run tests via nose
     """
-    config = load_configuration()
-    local('. ./{0}/bin/activate && nosetests -w {1}'.format(
-        config.venv_name(),
-        config.test_where(location)))
+    where = config.test_where(opts.suite)
+    local(
+        '. ./{0}/bin/activate && nosetests -w {1} {2}'.format(
+            config.venv_name(),
+            where,
+            opts.options
+        )
+    )
+
+
+def tox_test(config, opts):
+    """
+    tox test
+
+    activate venv and run tox test suite
+
+    """
+    local(
+        '. ./{0}/bin/activate && tox {1}'.format(
+            config.venv_name(),
+            opts.options
+        )
+    )
 
 
 def main():
@@ -49,10 +85,21 @@ def main():
     Execute test command
     """
     opts = build_parser(sys.argv)
-    if opts.suite is not None:
-        nose_test(opts.suite)
-    else:
-        nose_test('default')
+    config = load_configuration()
+    mode = config.test_mode(opts.suite)
+    if opts.mode:
+        mode =  opts.mode
+
+    # backwards compat: default to nosetests
+    if mode is None:
+        mode = 'nosetests'
+
+    if mode == 'nosetests':
+        nose_test(config, opts)
+        sys.exit(0)
+    if mode == 'tox':
+        tox_test(config, opts)
+        sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/src/cirrus/test.py
+++ b/src/cirrus/test.py
@@ -46,8 +46,7 @@ def build_parser(argslist):
     return opts
 
 
-@nottest
-def nose_test(config, opts):
+def nose_run(config, opts):
     """
     _nose_test_
 
@@ -63,7 +62,7 @@ def nose_test(config, opts):
     )
 
 
-def tox_test(config, opts):
+def tox_run(config, opts):
     """
     tox test
 

--- a/tests/unit/cirrus/test_test.py
+++ b/tests/unit/cirrus/test_test.py
@@ -4,17 +4,45 @@ test command tests
 import mock
 import unittest
 
-from cirrus.test import nose_test
+from cirrus.test import nose_test, tox_test
 
 
 class TestTest(unittest.TestCase):
 
+    def test_tox_test(self):
+        """test mox based test call"""
+        with mock.patch('cirrus.test.local') as mock_local:
+            mock_opts = mock.Mock()
+            mock_opts.suite = 'default'
+            mock_opts.options = '-o OPTION'
+            mock_config = mock.Mock()
+            mock_config.venv_name = mock.Mock()
+            mock_config.venv_name.return_value = "VENV"
+
+            tox_test(mock_config, mock_opts)
+            self.failUnless(mock_local.called)
+            self.failUnless(mock_config.venv_name.called)
+            command = mock_local.call_args[0][0]
+            self.assertEqual(command, '. ./VENV/bin/activate && tox -o OPTION')
+
     def test_nose_test(self):
-        with mock.patch('cirrus.test.load_configuration') as mock_config:
-            with mock.patch('cirrus.test.local') as mock_local:
-                nose_test('default')
-                self.failUnless(mock_config.called)
-                self.failUnless(mock_local.called)
+        """test nose_test call"""
+        with mock.patch('cirrus.test.local') as mock_local:
+            mock_opts = mock.Mock()
+            mock_opts.suite = 'default'
+            mock_opts.options = '-o OPTION'
+            mock_config = mock.Mock()
+            mock_config.venv_name = mock.Mock()
+            mock_config.venv_name.return_value = "VENV"
+            mock_config.test_where = mock.Mock()
+            mock_config.test_where.return_value = "WHERE"
+
+            nose_test(mock_config, mock_opts)
+            self.failUnless(mock_local.called)
+            self.failUnless(mock_config.venv_name.called)
+            self.failUnless(mock_config.test_where.called)
+            command = mock_local.call_args[0][0]
+            self.assertEqual(command, '. ./VENV/bin/activate && nosetests -w WHERE -o OPTION')
 
 
 if __name__ == "__main__":

--- a/tests/unit/cirrus/test_test.py
+++ b/tests/unit/cirrus/test_test.py
@@ -4,7 +4,8 @@ test command tests
 import mock
 import unittest
 
-from cirrus.test import nose_test, tox_test
+from cirrus.test import nose_run
+from cirrus.test import tox_run
 
 
 class TestTest(unittest.TestCase):
@@ -19,7 +20,7 @@ class TestTest(unittest.TestCase):
             mock_config.venv_name = mock.Mock()
             mock_config.venv_name.return_value = "VENV"
 
-            tox_test(mock_config, mock_opts)
+            tox_run(mock_config, mock_opts)
             self.failUnless(mock_local.called)
             self.failUnless(mock_config.venv_name.called)
             command = mock_local.call_args[0][0]
@@ -37,7 +38,7 @@ class TestTest(unittest.TestCase):
             mock_config.test_where = mock.Mock()
             mock_config.test_where.return_value = "WHERE"
 
-            nose_test(mock_config, mock_opts)
+            nose_run(mock_config, mock_opts)
             self.failUnless(mock_local.called)
             self.failUnless(mock_config.venv_name.called)
             self.failUnless(mock_config.test_where.called)


### PR DESCRIPTION
@jcounts @appeltel @ksnavely 

In this PR I refactor the test command slightly to allow support for tox tests as well as nosetests. 
If the new mode option isnt provided in either config or CLI opts, it falls back to nosetests so it should work in the same way as before. 