### PR TITLE
support multiple requirements, add no-setup-develop flag

### DIFF
--- a/src/cirrus/build.py
+++ b/src/cirrus/build.py
@@ -44,18 +44,26 @@ def build_parser(argslist):
         '-d',
         '--docs',
         nargs='*',
-        help='generate documentation with Sphinx (Makefile path must be set in cirrus.conf.')
+        help=(
+            'generate documentation with Sphinx '
+            '(Makefile path must be set in cirrus.conf.'
+        )
+    )
 
     parser.add_argument(
         '-u',
         '--upgrade',
         action='store_true',
         default=False,
-        help='Use --upgrade to update the dependencies in the package requirements'
+        help=(
+            'Use --upgrade to update the dependencies '
+            'in the package requirements'
+        )
     )
     parser.add_argument(
         '--extra-requirements',
-        nargs="+", type=str,
+        nargs="+",
+        type=str,
         dest='extras',
         help='extra requirements files to install'
     )
@@ -64,7 +72,7 @@ def build_parser(argslist):
         dest='nosetupdevelop',
         default=False,
         action='store_true'
-        )
+    )
     opts = parser.parse_args(argslist)
     return opts
 
@@ -107,7 +115,7 @@ def execute_build(opts):
     # remove existing virtual env if building clean
     if opts.clean and os.path.exists(venv_path):
         cmd = "rm -rf {0}".format(venv_path)
-        print "Removing existing virtualenv: {0}".format(venv_path)
+        LOGGER.info("Removing existing virtualenv: {0}".format(venv_path))
         local(cmd)
 
     if not os.path.exists(venv_bin_path):
@@ -120,24 +128,26 @@ def execute_build(opts):
     pip_command_base = None
     if pypi_server is not None:
         pypi_conf = get_pypi_auth()
-        pypi_url = "https://{pypi_username}:{pypi_token}@{pypi_server}/simple".format(
+        pypi_url = (
+            "https://{pypi_username}:{pypi_token}@{pypi_server}/simple"
+        ).format(
             pypi_token=pypi_conf['token'],
             pypi_username=pypi_conf['username'],
             pypi_server=pypi_server
         )
         pip_command_base = (
             '{0}/bin/pip install -i {1}'
-            ).format(venv_path, pypi_url)
+        ).format(venv_path, pypi_url)
         if opts.upgrade:
             cmd = (
                 '{0} --upgrade '
                 '-r {1}'
-                ).format(pip_command_base, reqs_name)
+            ).format(pip_command_base, reqs_name)
         else:
             cmd = (
                 '{0} '
                 '-r {1}'
-                ).format(pip_command_base, reqs_name)
+            ).format(pip_command_base, reqs_name)
 
     else:
         pip_command_base = '{0}/bin/pip install'.format(venv_path)
@@ -157,15 +167,21 @@ def execute_build(opts):
             "Working Dir: {2}\n"
             "Virtualenv: {3}\n"
             "Requirements: {4}\n"
-            ).format(ex, cmd, working_dir, venv_path, reqs_name)
-        LOGGER.info(msg)
+        ).format(ex, cmd, working_dir, venv_path, reqs_name)
+        LOGGER.error(msg)
         sys.exit(1)
 
     if extra_reqs:
         if opts.upgrade:
-            commands = ["{0} --upgrade -r {1}".format(pip_command_base, reqfile) for reqfile in opts.extras]
+            commands = [
+                "{0} --upgrade -r {1}".format(pip_command_base, reqfile)
+                for reqfile in opts.extras
+            ]
         else:
-            commands = ["{0} -r {1}".format(pip_command_base, reqfile) for reqfile in opts.extras]
+            commands = [
+                "{0} -r {1}".format(pip_command_base, reqfile)
+                for reqfile in opts.extras
+            ]
 
         for cmd in commands:
             LOGGER.info("Installing extra requirements... {}".format(cmd))
@@ -176,7 +192,7 @@ def execute_build(opts):
                     "Error running pip install command extra "
                     "requirements install: {}\n{}"
                 ).format(reqfile, ex)
-                LOGGER.info(msg)
+                LOGGER.error(msg)
                 sys.exit(1)
 
     # setup for development
@@ -185,7 +201,11 @@ def execute_build(opts):
         LOGGER.info(msg)
     else:
         LOGGER.info('running python setup.py develop...')
-        local('. ./{0}/bin/activate && python setup.py develop'.format(venv_name))
+        local(
+            '. ./{0}/bin/activate && python setup.py develop'.format(
+                venv_name
+            )
+        )
 
 
 def main():

--- a/tests/unit/cirrus/build_tests.py
+++ b/tests/unit/cirrus/build_tests.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python
+"""
+build command test coverage
+"""
+
+import unittest
+import mock
+
+from cirrus.build import execute_build, build_parser
+
+
+class BuildParserTests(unittest.TestCase):
+    """test build_parser"""
+
+    def test_build_parser(self):
+        """test parser setup"""
+        argv = ['build']
+        opts = build_parser(argv)
+        self.assertEqual(opts.clean, False)
+        self.assertEqual(opts.command, 'build')
+        self.assertEqual(opts.docs, None)
+        self.assertEqual(opts.extras, None)
+        self.assertEqual(opts.nosetupdevelop, False)
+        self.assertEqual(opts.upgrade, False)
+
+        argv = ['build', '--no-setup-develop']
+        opts = build_parser(argv)
+        self.failUnless(opts.nosetupdevelop)
+
+        argv = [
+            'build',
+            '--extra-requirements',
+            'test-requirements.txt',
+            ' other-requirements.txt'
+        ]
+        opts = build_parser(argv)
+        self.assertEqual(
+            opts.extras,
+            ['test-requirements.txt', ' other-requirements.txt']
+        )
+
+
+class BuildCommandTests(unittest.TestCase):
+    """test coverage for build command code"""
+    def setUp(self):
+        """set up patchers and mocks"""
+        self.conf_patcher = mock.patch('cirrus.build.load_configuration')
+        self.local_patcher = mock.patch('cirrus.build.local')
+        self.os_path_exists_patcher = mock.patch('cirrus.build.os.path.exists')
+        self.os_cwd_patcher = mock.patch('cirrus.build.os.getcwd')
+        self.pypi_auth_patcher = mock.patch('cirrus.build.get_pypi_auth')
+        self.cirrus_home_patcher = mock.patch('cirrus.build.cirrus_home')
+
+        self.build_params = {}
+        self.pypi_url_value = None
+
+        self.mock_load_conf = self.conf_patcher.start()
+        self.mock_conf = mock.Mock()
+        self.mock_load_conf.return_value = self.mock_conf
+        self.mock_conf.get = mock.Mock()
+        self.mock_conf.get.return_value = self.build_params
+        self.mock_conf.pypi_url = mock.Mock()
+        self.mock_conf.pypi_url.return_value = self.pypi_url_value
+        self.mock_local = self.local_patcher.start()
+        self.mock_os_exists = self.os_path_exists_patcher.start()
+        self.mock_os_exists.return_value = False
+        self.mock_pypi_auth = self.pypi_auth_patcher.start()
+        self.mock_os_cwd = self.os_cwd_patcher.start()
+        self.mock_os_cwd.return_value = 'CWD'
+        self.mock_cirrus_home = self.cirrus_home_patcher.start()
+        self.mock_cirrus_home.return_value = 'CIRRUS_HOME'
+
+        self.mock_pypi_auth.return_value = {
+            'username': 'PYPIUSERNAME',
+            'ssh_username': 'SSHUSERNAME',
+            'ssh_key': 'SSHKEY',
+            'token': 'TOKEN'
+        }
+
+    def tearDown(self):
+        self.conf_patcher.stop()
+        self.local_patcher.stop()
+        self.os_path_exists_patcher.stop()
+        self.pypi_auth_patcher.stop()
+        self.os_cwd_patcher.stop()
+        self.cirrus_home_patcher.stop()
+
+    def test_execute_build_default_pypi(self):
+        """test execute_build with default pypi settings"""
+        opts = mock.Mock()
+        opts.clean = False
+        opts.upgrade = False
+        opts.extras = []
+        opts.nosetupdevelop = False
+
+        execute_build(opts)
+
+        self.mock_local.assert_has_calls([
+            mock.call('CIRRUS_HOME/venv/bin/virtualenv CWD/venv'),
+            mock.call('CWD/venv/bin/pip install -r requirements.txt'),
+            mock.call('. ./venv/bin/activate && python setup.py develop')
+        ])
+
+    def test_execute_build_default_pypi_upgrade(self):
+        """test execute_build with default pypi settings and upgrade"""
+        opts = mock.Mock()
+        opts.clean = False
+        opts.upgrade = True
+        opts.extras = []
+        opts.nosetupdevelop = False
+
+        execute_build(opts)
+
+        self.mock_local.assert_has_calls([
+            mock.call('CIRRUS_HOME/venv/bin/virtualenv CWD/venv'),
+            mock.call('CWD/venv/bin/pip install --upgrade -r requirements.txt'),
+            mock.call('. ./venv/bin/activate && python setup.py develop')
+        ])
+
+    def test_execute_build_with_extras(self):
+        """test execute build with extra reqs"""
+        opts = mock.Mock()
+        opts.clean = False
+        opts.upgrade = False
+        opts.extras = ['test-requirements.txt']
+        opts.nosetupdevelop = False
+        execute_build(opts)
+        self.mock_local.assert_has_calls([
+            mock.call('CIRRUS_HOME/venv/bin/virtualenv CWD/venv'),
+            mock.call('CWD/venv/bin/pip install -r requirements.txt'),
+            mock.call('CWD/venv/bin/pip install -r test-requirements.txt'),
+            mock.call('. ./venv/bin/activate && python setup.py develop')
+        ])
+
+    def test_execute_build_with_nosetupdevelop(self):
+        """test nosetupdevelop option"""
+        opts = mock.Mock()
+        opts.clean = False
+        opts.extras = []
+        opts.upgrade = False
+        opts.nosetupdevelop = True
+
+        execute_build(opts)
+        self.mock_local.assert_has_calls([
+            mock.call('CIRRUS_HOME/venv/bin/virtualenv CWD/venv'),
+            mock.call('CWD/venv/bin/pip install -r requirements.txt')
+        ])
+
+    def test_execute_build_with_pypi(self):
+        """test execute build with pypi opts"""
+        opts = mock.Mock()
+        opts.clean = False
+        opts.extras = []
+        opts.upgrade = False
+        opts.nosetupdevelop = False
+        self.mock_conf.pypi_url.return_value = "PYPIURL"
+
+        execute_build(opts)
+
+        self.mock_local.assert_has_calls([
+            mock.call('CIRRUS_HOME/venv/bin/virtualenv CWD/venv'),
+            mock.call('CWD/venv/bin/pip install -i https://PYPIUSERNAME:TOKEN@PYPIURL/simple -r requirements.txt'),
+            mock.call('. ./venv/bin/activate && python setup.py develop')
+
+        ])
+
+    def test_execute_build_with_pypi_upgrade(self):
+        """test execute build with pypi opts and upgrade"""
+        opts = mock.Mock()
+        opts.clean = False
+        opts.extras = []
+        opts.nosetupdevelop = False
+        opts.upgrade = True
+        self.mock_conf.pypi_url.return_value = "PYPIURL"
+
+        execute_build(opts)
+
+        self.mock_local.assert_has_calls([
+            mock.call('CIRRUS_HOME/venv/bin/virtualenv CWD/venv'),
+            mock.call('CWD/venv/bin/pip install -i https://PYPIUSERNAME:TOKEN@PYPIURL/simple --upgrade -r requirements.txt'),
+            mock.call('. ./venv/bin/activate && python setup.py develop')
+
+        ])
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/cirrus/build_tests.py
+++ b/tests/unit/cirrus/build_tests.py
@@ -31,12 +31,12 @@ class BuildParserTests(unittest.TestCase):
             'build',
             '--extra-requirements',
             'test-requirements.txt',
-            ' other-requirements.txt'
+            'other-requirements.txt'
         ]
         opts = build_parser(argv)
         self.assertEqual(
             opts.extras,
-            ['test-requirements.txt', ' other-requirements.txt']
+            ['test-requirements.txt', 'other-requirements.txt']
         )
 
 
@@ -179,9 +179,7 @@ class BuildCommandTests(unittest.TestCase):
             mock.call('CIRRUS_HOME/venv/bin/virtualenv CWD/venv'),
             mock.call('CWD/venv/bin/pip install -i https://PYPIUSERNAME:TOKEN@PYPIURL/simple --upgrade -r requirements.txt'),
             mock.call('. ./venv/bin/activate && python setup.py develop')
-
         ])
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
@jcounts @appeltel @shudgston @ksnavely 

Allow additional requirements files (eg test-requirements.txt) to be handled via git cirrus build command as in https://github.com/evansde77/cirrus/issues/123

Add --no-setup-develop option as requested in https://github.com/evansde77/cirrus/issues/44

Add test coverage for build command module