### PR TITLE
Fix bugs found in the git cirrus docs command

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Options and config:
                 * doc_job - the name of the Jenkins job for the documentation build
                 * doc_var - the variable name which the uploaded documentation tarball will be accessed by (Jenkins File Parameter)
                 * arc_var - the variable that will be used to name the file/folder the archive should be unpacked to as determined by the name of the archive filename. I.e. package-0.0.0.tar.gz => package-0.0.0 (Jenkins String Parameter)
-                * extra_vars - a list of dicts containing any other variables needed for the Jenkins job
+                * extra_vars - boolean value indicating if there are move variables to send to Jenkins which should be defined in the section [jenkins_docs_extra_vars]
             2. in the [cirrus] section of your .gitconfig:
                 * buildserver-user - Jenkins username for authorization
                 * buildserver-token - token or password for authorization
@@ -327,6 +327,7 @@ doc_var = artifact
 arc_var = ARCHIVE
 extra_vars = True
 
-[extra_vars]
+[jenkins_docs_extra_vars]
 var = value
+var1 = value1
 ```

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ python library build, test and devop like things assistant
 Installation Prerequisites
 ==========================
 
-* Cirrus requires python 2.7 (support for python 3 is in the pipeline) as well as pip and virtualenv installed. 
-* Git tools are heavily used, git is a requirement as cirrus is accessed via git command aliases. 
+* Cirrus requires python 2.7 (support for python 3 is in the pipeline) as well as pip and virtualenv installed.
+* Git tools are heavily used, git is a requirement as cirrus is accessed via git command aliases.
 
 Installation as a user:
 =======================
@@ -21,7 +21,7 @@ bash installer.sh
 
 The installer script will set up an install of cirrus for you in your home directory
 and prompt for some info so that it can set up some parameters in your .gitconfig
-The installer will create a virtualenv and install cirrus from pip via the cirrus-cli package, installing the latest available version. 
+The installer will create a virtualenv and install cirrus from pip via the cirrus-cli package, installing the latest available version.
 
 
 
@@ -107,22 +107,22 @@ git cirrus feature new BRANCH_NAME --push
 git cirrus feature pull-request --title TITLE --body BODY --notify @AGITHUBUSER,@ANOTHERGITHUBUSER
 ```
 
-#### cirrus review 
-The cirrus review command provides some utilities for dealing with GitHub pull requests from the cirrus command line. 
+#### cirrus review
+The cirrus review command provides some utilities for dealing with GitHub pull requests from the cirrus command line.
 Available commands are:
 
  * git cirrus review list - list all open PRs for the repo, accepts -u or --user to filter for requests from a specific user
- * git cirrus review details - Get details for a specific PR, specified by --id 
- * git cirrus review plusone - Set a Github context for the PR to indicate that the PR has been approved 
- * git cirrus review review - Add a review comment to a PR, optionally adding the plusone flag to it as well 
+ * git cirrus review details - Get details for a specific PR, specified by --id
+ * git cirrus review plusone - Set a Github context for the PR to indicate that the PR has been approved
+ * git cirrus review review - Add a review comment to a PR, optionally adding the plusone flag to it as well
 
 
 Examples:
 
-```bash 
-git cirrus review list --user evansde77 # list open PRs by user evansde77 
+```bash
+git cirrus review list --user evansde77 # list open PRs by user evansde77
 git cirrus review list                  # list all open PRs
-git cirrus review plusone --id 500 -c "+1"      # adds the +1 context to the feature via a status update and sets it to success 
+git cirrus review plusone --id 500 -c "+1"      # adds the +1 context to the feature via a status update and sets it to success
 git cirrus review reviee --id 500 -m "great work, LGTM"  --plus-one -c "+1" # adds a comment to the PR and sets the +1 context status to success
 ```
 
@@ -133,7 +133,7 @@ There are three subcommands:
 1. new - creates a new release branch, increments the package version, builds the release notes if configured.
 2. build - Runs sdist to create a new build artifact from the release branch
 3. merge - Runs git-flow style branch merges back to master and develop, optionally waiting on CI or setting flags for GH build contexts if needed
-4. upload - Pushes the build artifact to the pypi server configured in the cirrus conf, using a plugin system to allow for customisation. 
+4. upload - Pushes the build artifact to the pypi server configured in the cirrus conf, using a plugin system to allow for customisation.
 
 Usage:
 ```bash
@@ -141,7 +141,7 @@ git cirrus test # Stop if things are broken
 git cirrus release new --micro
 git cirrus release build
 git cirrus release merge --cleanup
-git cirrus release upload --plugin pypi 
+git cirrus release upload --plugin pypi
 ```
 
 Options:
@@ -149,15 +149,15 @@ Options:
 1. release new requires one of --micro, --minor or --macro to indicate which semantic version field to increment
 2. --bump adds or updates a package==version pair in requirements.txt, e.g. `--bump foo==0.0.9 bar==1.2.3`.
 3. release merge supports the following options:
-  * --cleanup - removes the remote and local release branch on successful merge 
+  * --cleanup - removes the remote and local release branch on successful merge
   * --context-string - Update the github context string provided when pushed
   * --wait-on-ci - Wait for GitHub CI status to be success before uploading
 4. upload will push the new release and upload the build artifact to pypi, but may take several non-required options:
-  * --plugin - Name of the upload plugin module. Options are found in [https://github.com/evansde77/cirrus/tree/develop/src/cirrus/plugins/uploaders](cirrus/plugins/uploaders) and can be used to customise the upload process. The pypi plugin does a standard sdist upload to the pypi server configured in your pypirc. The fabric plugin uses fabric to scp the artifact to a custom pypi server. 
+  * --plugin - Name of the upload plugin module. Options are found in [https://github.com/evansde77/cirrus/tree/develop/src/cirrus/plugins/uploaders](cirrus/plugins/uploaders) and can be used to customise the upload process. The pypi plugin does a standard sdist upload to the pypi server configured in your pypirc. The fabric plugin uses fabric to scp the artifact to a custom pypi server.
   * --test do not push new release or upload build artifact to pypi
   * --pypi-sudo, --no-pypi-sudo use or do not use sudo to move the build artifact to the correct location in the pypi server, defaults to using sudo
-  * --pypi-url URL override the pypi url from cirrus.conf with URL, equivalent to the -r option for pypi.python.org uploads, can specify a url or a shorthand name from your pypirc. 
-  
+  * --pypi-url URL override the pypi url from cirrus.conf with URL, equivalent to the -r option for pypi.python.org uploads, can specify a url or a shorthand name from your pypirc.
+
 
 Release Options in cirrus.conf
 
@@ -166,16 +166,16 @@ You can customise the release merge workflow for each package via the cirrus con
  * wait_on_ci - Set true to enable waiting on CI builds for the release branch, defaults to False, this will make the merge command poll the GH status API for the commit and wait for it to become success
  * wait_on_ci_develop - Set true to enable waiting on CI builds for the develop branch, defaults to False
  * wait_on_ci_master - Set true to enable waiting on CI builds for the master branch, defaults to False
- * wait_on_ci_timeout - Timeout in seconds to give up on waiting on CI, defaults to 600s (10 mins) 
+ * wait_on_ci_timeout - Timeout in seconds to give up on waiting on CI, defaults to 600s (10 mins)
  * wait_on_ci_interval - Interval to poll status in seconds, defaults to 2 seconds
  * github_context_string - The github context to update status for if update_github_context is True  Eg: continuous-integration/travis-ci
  * update_github_context - An alternative to waiting on CI, you can simply flip the status for a context to success if eg you have protected branches without a CI build to wait for. Requires a context to be provided via the github_context_string setting
- * push_retry_attempts - Optional number of attempts to try to push during merge 
+ * push_retry_attempts - Optional number of attempts to try to push during merge
  * push_retry_cooloff - Optional time to wait between retries in seconds
 
 Example:
 
-```ini 
+```ini
 [release]
 wait_on_ci = False
 wait_on_ci_develop = False
@@ -188,13 +188,13 @@ push_retry_attempts = 10
 push_retry_cooloff = 2
 ```
 
-##### Working with GitHub protected branches 
+##### Working with GitHub protected branches
 
-The release command works with two possible mode of [https://github.com/blog/2051-protected-branches-and-required-status-checks](GitHub branch protection) one in which you wait for the CI tests to run and update the status, and one in which there are no checks, so that you have to set status to merge branches in a git flow style. 
+The release command works with two possible mode of [https://github.com/blog/2051-protected-branches-and-required-status-checks](GitHub branch protection) one in which you wait for the CI tests to run and update the status, and one in which there are no checks, so that you have to set status to merge branches in a git flow style.
 
-For the waiting mode, simply flip the boolean wait_on_ci flag to True to wait on CI to run on the release branch. Likewise, the wait_on_ci_develop and wait_on_ci_master params will wait on CI status for the develop and master branches you have configured before merging. You can adjust the total timeout in seconds and the poll interval via the cirrus config file. 
+For the waiting mode, simply flip the boolean wait_on_ci flag to True to wait on CI to run on the release branch. Likewise, the wait_on_ci_develop and wait_on_ci_master params will wait on CI status for the develop and master branches you have configured before merging. You can adjust the total timeout in seconds and the poll interval via the cirrus config file.
 
-For the non-waiting mode, you provide the github context string you want to set and then when the merges back to develop and master occur, that state value is set to success. This mode of operation is useful when your CI system runs release tests in a way not connected to github, but you still have protected branches. 
+For the non-waiting mode, you provide the github context string you want to set and then when the merges back to develop and master occur, that state value is set to success. This mode of operation is useful when your CI system runs release tests in a way not connected to github, but you still have protected branches.
 
 ##### release tips
 
@@ -241,17 +241,17 @@ Specific files may be ran using '--files' OR check only files that have not yet 
 For pylint, a score threshold must be set in cirrus.conf [quality] threshold. The path to an optional rcfile (pylint configuration) may be set at [quality] rcfile.
 
 
-#### cirrus deploy 
+#### cirrus deploy
 
-The deploy command provides a plugin driven way to hook into deployment systems like chef and puppet. 
-Since deployment is heavily customisable based on what system is in use, the command supports selecting a plugin and then delegates all CLI options to that plugin. 
+The deploy command provides a plugin driven way to hook into deployment systems like chef and puppet.
+Since deployment is heavily customisable based on what system is in use, the command supports selecting a plugin and then delegates all CLI options to that plugin.
 
 Usage:
-```bash 
+```bash
 git cirrus deploy --plugin=<plugin_name>  <options for plugin>
 ```
 
-Deployer plugins live in [cirrus.plugins.deployers](https://github.com/evansde77/cirrus/tree/develop/src/cirrus/plugins/deployers) and individual docs for each plugin can be found there. 
+Deployer plugins live in [cirrus.plugins.deployers](https://github.com/evansde77/cirrus/tree/develop/src/cirrus/plugins/deployers) and individual docs for each plugin can be found there.
 
 Plugins:
 
@@ -306,9 +306,9 @@ Example cirrus.conf:
 
 ```ini
 [doc]
-sphinx_makefile_dir = ./docs/
-sphinx_doc_dir = ./docs/_build/html
-artifact_dir = ./docs/artifacts
+sphinx_makefile_dir = docs/
+sphinx_doc_dir = docs/_build/html
+artifact_dir = docs/artifacts
 publisher = doc_file_server
 
 [doc_file_server]
@@ -321,11 +321,12 @@ If using `publisher = jenkins`:
 
 ```ini
 [jenkins]
-url = https://hostname
+url = https://localhost:8080
 doc_job = doc_build
 doc_var = artifact
 arc_var = ARCHIVE
-extra_vars = [
-    {'name': 'FOO', 'value': 'bar'}
-]
+extra_vars = True
+
+[extra_vars]
+var = value
 ```

--- a/src/cirrus/docs.py
+++ b/src/cirrus/docs.py
@@ -46,6 +46,7 @@ def build_parser(argslist):
         action='store_true',
         help='test only, do not actually publish documentation'
     )
+    publish_command.set_defaults(test=False)
 
     opts = parser.parse_args(argslist)
     return opts

--- a/src/cirrus/docs.py
+++ b/src/cirrus/docs.py
@@ -34,13 +34,18 @@ def build_parser(argslist):
               'to run the Sphinx make command. Default: clean html'))
     build_command.set_defaults(make=[])
 
-    pack_command = subparsers.add_parser(
+    subparsers.add_parser(
         'pack',
         help='Package documentation as a tarball')
 
     publish_command = subparsers.add_parser(
         'publish',
         help='Publish documentation as specified in cirrus.conf')
+    publish_command.add_argument(
+        '--test',
+        action='store_true',
+        help='test only, do not actually publish documentation'
+    )
 
     opts = parser.parse_args(argslist)
     return opts

--- a/src/cirrus/documentation_utils.py
+++ b/src/cirrus/documentation_utils.py
@@ -5,7 +5,6 @@ _documentation_utils_
 utils for building and uploading Sphinx documentation
 
 """
-import json
 import os
 import sys
 import tarfile
@@ -167,5 +166,5 @@ def publish_documentation(opts):
         )
         return
 
-    plugin.publish(opts, doc_artifact)
+    plugin.publish(doc_artifact)
     return

--- a/src/cirrus/plugins/publishers/doc_file_server.py
+++ b/src/cirrus/plugins/publishers/doc_file_server.py
@@ -17,7 +17,7 @@ LOGGER = get_logger()
 class Documentation(Publisher):
     PLUGGAGE_OBJECT_NAME = 'doc_file_server'
 
-    def publish(self, opts, doc_artifact):
+    def publish(self, doc_artifact):
         """
         publish docs to a remote server via fabric over ssh.
 
@@ -43,7 +43,7 @@ class Documentation(Publisher):
         """
         fs_creds = self.package_conf.credentials.file_server_credentials()
         fs_username = fs_creds['file_server_username']
-        fs_keyfile = file_server_creds['file_server_keyfile']
+        fs_keyfile = fs_creds['file_server_keyfile']
 
         try:
             fs_config = self.package_conf['doc_file_server']
@@ -61,7 +61,13 @@ class Documentation(Publisher):
             )
             raise RuntimeError(msg)
 
+        # need to check for True as a string because ConfigParser always
+        # stores values internally as strings
+        use_sudo = False
+        if fs_config.get('doc_file_server_sudo').lower() == 'true':
+            use_sudo = True
+
         LOGGER.info("Uploading {0} to {1}".format(doc_artifact, fs_url))
         with FabricHelper(fs_url, fs_username, fs_keyfile):
             # fabric put the file onto the file server
-            put(doc_artifact, fs_upload_path, use_sudo=fs_config.get('doc_file_server_sudo', False))
+            put(doc_artifact, fs_upload_path, use_sudo=use_sudo)

--- a/src/cirrus/plugins/publishers/doc_file_server.py
+++ b/src/cirrus/plugins/publishers/doc_file_server.py
@@ -64,7 +64,7 @@ class Documentation(Publisher):
         # need to check for True as a string because ConfigParser always
         # stores values internally as strings
         use_sudo = False
-        if fs_config.get('doc_file_server_sudo').lower() == 'true':
+        if fs_config.get('doc_file_server_sudo', 'False').lower() == 'true':
             use_sudo = True
 
         LOGGER.info("Uploading {0} to {1}".format(doc_artifact, fs_url))

--- a/src/cirrus/plugins/publishers/jenkins.py
+++ b/src/cirrus/plugins/publishers/jenkins.py
@@ -39,7 +39,7 @@ class Documentation(Publisher):
         arc_var = ARCNAME
         extra_vars = True
 
-        [extra_vars]
+        [jenkins_docs_extra_vars]
         var1 = value
         var2 = value
 
@@ -51,9 +51,9 @@ class Documentation(Publisher):
             the archive should be unpacked to as determined by the name of the
             archive filename. I.e. package-0.0.0.tar.gz => package-0.0.0
 
-        .. note:: extra_vars is a boolean. When True a section named [extra_vars]
-            should be added to cirrus.conf containing any other variables
-            necessary for the Jenkins build.
+        .. note:: extra_vars is a boolean. When True a section named
+            [jenkins_docs_extra_vars] should be added to cirrus.conf containing
+            any other variables necessary for the Jenkins build.
         """
         try:
             jenkins_config = self.package_conf['jenkins']
@@ -68,7 +68,7 @@ class Documentation(Publisher):
                 '\n arc_var = ARCNAME'
                 '\n extra_vars = True'
                 '\n '
-                '\n [extra_vars]'
+                '\n [jenkins_docs_extra_vars]'
                 '\n varname = value'
                 '\n varname1 = value1'
             )
@@ -86,8 +86,8 @@ class Documentation(Publisher):
 
         # need to check for True as a string because ConfigParser always
         # stores values internally as strings
-        if jenkins_config.get('extra_vars').lower() == 'true':
-            extra_vars = self.package_conf.get('extra_vars', {})
+        if jenkins_config.get('extra_vars', 'False').lower() == 'true':
+            extra_vars = self.package_conf.get('jenkins_docs_extra_vars', {})
             for k, v in extra_vars.iteritems():
                 build_params['parameter'].append({"name": k, "value": v})
 

--- a/src/cirrus/publish_plugins.py
+++ b/src/cirrus/publish_plugins.py
@@ -18,17 +18,14 @@ class Publisher(PluggagePlugin):
     PLUGGAGE_FACTORY_NAME = 'publish'
 
     def __init__(self):
-        super(Uploader, self).__init__()
+        super(Publisher, self).__init__()
         self.package_conf = load_configuration()
 
-    def publish(self, opts, doc_artifact):
+    def publish(self, doc_artifact):
         """
         _publish_
 
         Override this method to publish the documentation.
-
-        :param opts: The argparse opts object from the command
-            parser
 
         :param doc_artifact: path to the documentation tarball to publish
 

--- a/tests/unit/cirrus/documentation_utils_test.py
+++ b/tests/unit/cirrus/documentation_utils_test.py
@@ -2,7 +2,6 @@
 documentation utils tests
 
 """
-import __builtin__
 import mock
 import os
 import tempfile
@@ -90,7 +89,7 @@ class TestDocumentationUtils(unittest.TestCase):
         publish_documentation(opts)
         self.assertTrue(plugin.publish.called)
         plugin.publish.assert_has_calls(
-            [mock.call(opts, self.doc_artifact_name)]
+            [mock.call(self.doc_artifact_name)]
         )
 
 if __name__ == '__main__':

--- a/tests/unit/cirrus/publisher_plugins_tests.py
+++ b/tests/unit/cirrus/publisher_plugins_tests.py
@@ -1,5 +1,4 @@
 import __builtin__
-import json
 import mock
 import os
 import tempfile
@@ -13,6 +12,14 @@ from harnesses import CirrusConfigurationHarness, write_cirrus_conf
 
 
 class FileServerPublisherTests(unittest.TestCase):
+    """
+    Test the doc_file_server publisher plugin.
+
+    A test config is defined with the values required to publish
+    documentation using the doc_file_server plugin which uses Fabric
+    put to upload the doc artifact to a remote server
+
+    """
 
     def setUp(self):
         self.dir = tempfile.mkdtemp()
@@ -56,6 +63,9 @@ class FileServerPublisherTests(unittest.TestCase):
     @mock.patch('cirrus.plugins.publishers.doc_file_server.put')
     @mock.patch('cirrus.plugins.publishers.doc_file_server.FabricHelper')
     def test_docs_file_server(self, m_fabric, m_fabric_put):
+        """
+        test docs_file_server publisher plugin makes put command with Fabric
+        """
         factory = pluggage.registry.get_factory(
             'publish',
             load_modules=['cirrus.plugins.publishers']
@@ -71,6 +81,15 @@ class FileServerPublisherTests(unittest.TestCase):
 
 
 class JenkinsPublisherTests(unittest.TestCase):
+    """
+    Test the jenkins publisher plugin.
+
+    A test config is defined with the values required to publish
+    documentation using the jenkins plugin which issues an API request
+    to Jenkins which uploads the documentation artifact and required
+    parameters to a Jenkins job.
+
+    """
 
     def setUp(self):
         self.dir = tempfile.mkdtemp()
@@ -94,7 +113,7 @@ class JenkinsPublisherTests(unittest.TestCase):
                     'arc_var': 'ARCNAME',
                     'extra_vars': True
                 },
-                'extra_vars': {
+                'jenkins_docs_extra_vars': {
                     'PROJECT': 'cirrus_unittest'
                 }
             }
@@ -112,6 +131,11 @@ class JenkinsPublisherTests(unittest.TestCase):
     @mock.patch('cirrus.plugins.jenkins.get_buildserver_auth')
     @mock.patch('cirrus.plugins.publishers.jenkins.MultipartEncoder')
     def test_jenkins(self, m_encoder, m_auth, m_requests):
+        """
+        test jenkins publisher plugin uses MultipartEncoder to encode form
+        data which is then sent to Jenkins via a POST to the Jenkins /build
+        endpoint
+        """
         factory = pluggage.registry.get_factory(
             'publish',
             load_modules=['cirrus.plugins.publishers']

--- a/tests/unit/cirrus/publisher_plugins_tests.py
+++ b/tests/unit/cirrus/publisher_plugins_tests.py
@@ -1,0 +1,137 @@
+import __builtin__
+import json
+import mock
+import os
+import tempfile
+import unittest
+
+import pluggage.registry
+
+from cirrus.documentation_utils import doc_artifact_name
+
+from harnesses import CirrusConfigurationHarness, write_cirrus_conf
+
+
+class FileServerPublisherTests(unittest.TestCase):
+
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.config = os.path.join(self.dir, 'cirrus.conf')
+        self.makefile_dir = os.path.join(self.dir, 'docs')
+        self.artifact_dir = os.path.join(self.dir, 'artifacts')
+        self.doc_dir = os.path.join(self.dir, 'docs/_build/html')
+        write_cirrus_conf(self.config,
+            **{
+                'package': {'name': 'cirrus_unittest', 'version': '1.2.3'},
+                'doc': {
+                    'publisher': 'doc_file_server',
+                    'sphinx_makefile_dir': self.doc_dir,
+                    'sphinx_doc_dir': self.doc_dir,
+                    'artifact_dir': self.artifact_dir
+                },
+                'doc_file_server': {
+                    'doc_file_server_url': 'http://localhost:8080',
+                    'doc_file_server_upload_path': '/path/to/upload/dir'
+                }
+            }
+        )
+        self.harness = CirrusConfigurationHarness('cirrus.publish_plugins.load_configuration', self.config)
+        self.harness.setUp()
+
+        self.harness.config.credentials = mock.Mock()
+        self.harness.config.credentials.file_server_credentials = mock.Mock(
+            return_value={
+                'file_server_username': 'username',
+                'file_server_keyfile': '/path/to/ssh/keyfile'
+            }
+        )
+
+        self.doc_artifact_name = doc_artifact_name(self.harness.config)
+
+    def tearDown(self):
+        self.harness.tearDown()
+        if os.path.exists(self.dir):
+            os.system('rm -rf {0}'.format(self.dir))
+
+    @mock.patch('cirrus.plugins.publishers.doc_file_server.put')
+    @mock.patch('cirrus.plugins.publishers.doc_file_server.FabricHelper')
+    def test_docs_file_server(self, m_fabric, m_fabric_put):
+        factory = pluggage.registry.get_factory(
+            'publish',
+            load_modules=['cirrus.plugins.publishers']
+        )
+        plugin = factory('doc_file_server')
+
+        plugin.publish(self.doc_artifact_name)
+
+        self.assertTrue(m_fabric.called_once_with(
+            'http://localhost:8080', 'username', '/path/to/ssh/keyfile'))
+        self.assertTrue(m_fabric_put.called_once_with(
+            self.doc_artifact_name, '/path/to/upload/dir', sudo=False))
+
+
+class JenkinsPublisherTests(unittest.TestCase):
+
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.config = os.path.join(self.dir, 'cirrus.conf')
+        self.makefile_dir = os.path.join(self.dir, 'docs')
+        self.artifact_dir = os.path.join(self.dir, 'artifacts')
+        self.doc_dir = os.path.join(self.dir, 'docs/_build/html')
+        write_cirrus_conf(self.config,
+            **{
+                'package': {'name': 'cirrus_unittest', 'version': '1.2.3'},
+                'doc': {
+                    'publisher': 'jenkins',
+                    'sphinx_makefile_dir': self.doc_dir,
+                    'sphinx_doc_dir': self.doc_dir,
+                    'artifact_dir': self.artifact_dir
+                },
+                'jenkins': {
+                    'url': 'http://localhost:8080',
+                    'doc_job': 'default',
+                    'doc_var': 'ARCHIVE',
+                    'arc_var': 'ARCNAME',
+                    'extra_vars': True
+                },
+                'extra_vars': {
+                    'PROJECT': 'cirrus_unittest'
+                }
+            }
+        )
+        self.harness = CirrusConfigurationHarness('cirrus.publish_plugins.load_configuration', self.config)
+        self.harness.setUp()
+        self.doc_artifact_name = doc_artifact_name(self.harness.config)
+
+    def tearDown(self):
+        self.harness.tearDown()
+        if os.path.exists(self.dir):
+            os.system('rm -rf {0}'.format(self.dir))
+
+    @mock.patch('cirrus.plugins.jenkins.requests')
+    @mock.patch('cirrus.plugins.jenkins.get_buildserver_auth')
+    @mock.patch('cirrus.plugins.publishers.jenkins.MultipartEncoder')
+    def test_jenkins(self, m_encoder, m_auth, m_requests):
+        factory = pluggage.registry.get_factory(
+            'publish',
+            load_modules=['cirrus.plugins.publishers']
+        )
+        plugin = factory('jenkins')
+
+        m_session = mock.Mock()
+        m_requests.Session = mock.Mock(return_value=m_session)
+        m_resp = mock.Mock()
+        m_resp.status_code = 201
+        m_session.post = mock.Mock(return_value=m_resp)
+
+        with mock.patch('__builtin__.open') as m_open:
+
+            plugin.publish(self.doc_artifact_name)
+
+            self.assertEqual(m_encoder.call_count, 1)
+            self.assertEqual(m_open.call_count, 1)
+            self.assertEqual(m_session.post.call_count, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- publish_plugins.py: fix `__init__` super() function call
- docs.py: add --test option to publish command
- doc_file_server.py: fix variable name, file_server_creds['file_server_keyfile'] => fs_creds['file_server_keyfile']

- plugins/publishers/jenkins.py: add missing import (os), rework how extra_vars are added. Due to how ConfigParser works, the elements of the extra_vars list are read as strings, not dicts. This changes the extra_vars config option to a boolean, and if true, a section named [extra_vars] should be added to cirrus.conf to define the variables. This makes that whole section a dict once parsed so the key/value pairs can be parsed to the proper format for triggering the jenkins job.

- check for extra_vars by comparing strings in jenkins publisher plugin, and check for file_server_sudo via string comparison in doc_file_server publisher plugin, because the config parser stores all values as strings so it won't recognize True/False as booleans

- documentation_utils.py: remove unused import (json)
- remove opts from args for Publisher plugins because it is unused

- modify doc utils tests to account for the removal of opts from the publisher function args
- add unit tests for publisher plugins

update git cirrus docs section of the README for changes to cirrus.conf setup

(sorry for all the whitespace changes in README, my editor automatically strips whitespaces at the end of lines)

@evansde77 