### PR TITLE
Feature/read pypirc

### DIFF
--- a/src/cirrus/build.py
+++ b/src/cirrus/build.py
@@ -16,6 +16,7 @@ from argparse import ArgumentParser
 from cirrus.documentation_utils import build_docs
 from cirrus.environment import cirrus_home
 from cirrus.configuration import load_configuration, get_pypi_auth
+from cirrus.pypirc import PypircFile
 from cirrus.logger import get_logger
 from fabric.operations import local
 
@@ -126,19 +127,29 @@ def execute_build(opts):
 
     # custom pypi server
     pypi_server = config.pypi_url()
+    pip_options = config.pip_options()
     pip_command_base = None
     if pypi_server is not None:
-        pypi_conf = get_pypi_auth()
-        pypi_url = (
-            "https://{pypi_username}:{pypi_token}@{pypi_server}/simple"
-        ).format(
-            pypi_token=pypi_conf['token'],
-            pypi_username=pypi_conf['username'],
-            pypi_server=pypi_server
-        )
+
+        pypirc = PypircFile()
+        if pypi_server in pypirc.index_servers:
+            pypi_url = pypirc.get_pypi_url(pypi_server)
+        else:
+            pypi_conf = get_pypi_auth()
+            pypi_url = (
+                "https://{pypi_username}:{pypi_token}@{pypi_server}/simple"
+            ).format(
+                pypi_token=pypi_conf['token'],
+                pypi_username=pypi_conf['username'],
+                pypi_server=pypi_server
+            )
+
         pip_command_base = (
             '{0}/bin/pip install -i {1}'
         ).format(venv_path, pypi_url)
+        if pip_options:
+            pip_command_base += " {} ".format(pip_options)
+
         if opts.upgrade:
             cmd = (
                 '{0} --upgrade '
@@ -152,6 +163,9 @@ def execute_build(opts):
 
     else:
         pip_command_base = '{0}/bin/pip install'.format(venv_path)
+        if pip_options:
+            pip_command_base += " {} ".format(pip_options)
+
         # no pypi server
         if opts.upgrade:
             cmd = '{0} --upgrade -r {1}'.format(pip_command_base, reqs_name)

--- a/src/cirrus/build.py
+++ b/src/cirrus/build.py
@@ -147,8 +147,6 @@ def execute_build(opts):
         pip_command_base = (
             '{0}/bin/pip install -i {1}'
         ).format(venv_path, pypi_url)
-        if pip_options:
-            pip_command_base += " {} ".format(pip_options)
 
         if opts.upgrade:
             cmd = (
@@ -163,14 +161,14 @@ def execute_build(opts):
 
     else:
         pip_command_base = '{0}/bin/pip install'.format(venv_path)
-        if pip_options:
-            pip_command_base += " {} ".format(pip_options)
-
         # no pypi server
         if opts.upgrade:
             cmd = '{0} --upgrade -r {1}'.format(pip_command_base, reqs_name)
         else:
             cmd = '{0} -r {1}'.format(pip_command_base, reqs_name)
+
+    if pip_options:
+        cmd += " {} ".format(pip_options)
 
     try:
         local(cmd)

--- a/src/cirrus/configuration.py
+++ b/src/cirrus/configuration.py
@@ -134,6 +134,9 @@ class Configuration(dict):
     def pypi_url(self):
         return self.get('pypi', {}).get('pypi_url')
 
+    def pip_options(self):
+        return self.get('pypi', {}).get('pip_options')
+
     def pypi_config(self):
         """
         get the details for uploading to pypi

--- a/src/cirrus/pypirc.py
+++ b/src/cirrus/pypirc.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+"""
+.pypirc file wrapper
+
+"""
+import os
+import ConfigParser
+
+
+class PypircFile(dict):
+    """
+    wrapper object for a pypirc file
+
+    """
+    def __init__(self, filename='~/.pypirc'):
+        self.config_file = os.path.expanduser(filename)
+        if os.path.exists(self.config_file):
+            self.load()
+
+    def load(self):
+        """parse config file into self"""
+        self.parser = ConfigParser.RawConfigParser()
+        self.parser.read(self.config_file)
+        for section in self.parser.sections():
+            self.setdefault(section, {})
+            for option in self.parser.options(section):
+                self[section].setdefault(
+                    option,
+                    self.parser.get(section, option)
+                )
+
+    @property
+    def index_servers(self):
+        """get list of index servers defined in pypirc"""
+        servers = self.get('distutils', {}).get('index-servers', '')
+        return [s.strip() for s in servers.split('\n') if s.strip()]
+
+    def get_pypi_config(self, index_alias):
+        """get pypi config for a given index alias"""
+        if index_alias not in self.index_servers:
+            msg = "Unknown pypi index name: {}".format(index_alias)
+            raise RuntimeError(msg)
+        return self[index_alias]

--- a/src/cirrus/pypirc.py
+++ b/src/cirrus/pypirc.py
@@ -14,8 +14,11 @@ class PypircFile(dict):
     """
     def __init__(self, filename='~/.pypirc'):
         self.config_file = os.path.expanduser(filename)
-        if os.path.exists(self.config_file):
+        if self.exists():
             self.load()
+
+    def exists(self):
+        return os.path.exists(self.config_file)
 
     def load(self):
         """parse config file into self"""
@@ -41,3 +44,20 @@ class PypircFile(dict):
             msg = "Unknown pypi index name: {}".format(index_alias)
             raise RuntimeError(msg)
         return self[index_alias]
+
+    def get_pypi_url(self, index_alias):
+        if index_alias not in self.index_servers:
+            msg = "Unknown pypi index name: {}".format(index_alias)
+            raise RuntimeError(msg)
+        params = self[index_alias]
+        url = (
+            "https://{username}:{password}@{repository}/simple"
+        ).format(**params)
+        return url
+
+
+if __name__ == '__main__':
+    p = PypircFile()
+    print p.get_pypi_config('imc-dev')
+    print p.get_pypi_url('imc-dev')
+

--- a/src/cirrus/pypirc.py
+++ b/src/cirrus/pypirc.py
@@ -38,13 +38,6 @@ class PypircFile(dict):
         servers = self.get('distutils', {}).get('index-servers', '')
         return [s.strip() for s in servers.split('\n') if s.strip()]
 
-    def get_pypi_config(self, index_alias):
-        """get pypi config for a given index alias"""
-        if index_alias not in self.index_servers:
-            msg = "Unknown pypi index name: {}".format(index_alias)
-            raise RuntimeError(msg)
-        return self[index_alias]
-
     def get_pypi_url(self, index_alias):
         if index_alias not in self.index_servers:
             msg = "Unknown pypi index name: {}".format(index_alias)
@@ -54,10 +47,3 @@ class PypircFile(dict):
             "https://{username}:{password}@{repository}/simple"
         ).format(**params)
         return url
-
-
-if __name__ == '__main__':
-    p = PypircFile()
-    print p.get_pypi_config('imc-dev')
-    print p.get_pypi_url('imc-dev')
-

--- a/tests/unit/cirrus/build_tests.py
+++ b/tests/unit/cirrus/build_tests.py
@@ -50,9 +50,13 @@ class BuildCommandTests(unittest.TestCase):
         self.os_cwd_patcher = mock.patch('cirrus.build.os.getcwd')
         self.pypi_auth_patcher = mock.patch('cirrus.build.get_pypi_auth')
         self.cirrus_home_patcher = mock.patch('cirrus.build.cirrus_home')
+        self.pypirc_patcher = mock.patch('cirrus.build.PypircFile')
 
         self.build_params = {}
         self.pypi_url_value = None
+
+        self.mock_pypirc_inst = mock.Mock()
+        self.mock_pypirc_inst.index_servers = []
 
         self.mock_load_conf = self.conf_patcher.start()
         self.mock_conf = mock.Mock()
@@ -61,6 +65,7 @@ class BuildCommandTests(unittest.TestCase):
         self.mock_conf.get.return_value = self.build_params
         self.mock_conf.pypi_url = mock.Mock()
         self.mock_conf.pypi_url.return_value = self.pypi_url_value
+        self.mock_conf.pip_options = mock.Mock(return_value=None)
         self.mock_local = self.local_patcher.start()
         self.mock_os_exists = self.os_path_exists_patcher.start()
         self.mock_os_exists.return_value = False
@@ -69,6 +74,10 @@ class BuildCommandTests(unittest.TestCase):
         self.mock_os_cwd.return_value = 'CWD'
         self.mock_cirrus_home = self.cirrus_home_patcher.start()
         self.mock_cirrus_home.return_value = 'CIRRUS_HOME'
+        self.mock_pypirc = self.pypirc_patcher.start()
+        self.mock_pypirc.return_value = self.mock_pypirc_inst
+
+
 
         self.mock_pypi_auth.return_value = {
             'username': 'PYPIUSERNAME',
@@ -84,6 +93,7 @@ class BuildCommandTests(unittest.TestCase):
         self.pypi_auth_patcher.stop()
         self.os_cwd_patcher.stop()
         self.cirrus_home_patcher.stop()
+        self.pypirc_patcher.stop()
 
     def test_execute_build_default_pypi(self):
         """test execute_build with default pypi settings"""
@@ -98,6 +108,43 @@ class BuildCommandTests(unittest.TestCase):
         self.mock_local.assert_has_calls([
             mock.call('CIRRUS_HOME/venv/bin/virtualenv CWD/venv'),
             mock.call('CWD/venv/bin/pip install -r requirements.txt'),
+            mock.call('. ./venv/bin/activate && python setup.py develop')
+        ])
+
+    def test_execute_build_pypirc(self):
+        """test execute_build with pypirc provided settings"""
+        opts = mock.Mock()
+        opts.clean = False
+        opts.upgrade = False
+        opts.extras = []
+        opts.nosetupdevelop = False
+
+        self.mock_conf.pypi_url.return_value = "dev"
+        self.mock_pypirc_inst.index_servers = ['dev']
+        self.mock_pypirc_inst.get_pypi_url = mock.Mock(return_value="DEVPYPIURL")
+        execute_build(opts)
+
+        self.mock_local.assert_has_calls([
+            mock.call('CIRRUS_HOME/venv/bin/virtualenv CWD/venv'),
+            mock.call('CWD/venv/bin/pip install -i DEVPYPIURL -r requirements.txt'),
+            mock.call('. ./venv/bin/activate && python setup.py develop')
+        ])
+
+
+
+    def test_execute_build_default_pypi_pip_options(self):
+        """test execute_build with default pypi settings"""
+        opts = mock.Mock()
+        opts.clean = False
+        opts.upgrade = False
+        opts.extras = []
+        opts.nosetupdevelop = False
+        self.mock_conf.pip_options.return_value = "PIPOPTIONS"
+        execute_build(opts)
+
+        self.mock_local.assert_has_calls([
+            mock.call('CIRRUS_HOME/venv/bin/virtualenv CWD/venv'),
+            mock.call('CWD/venv/bin/pip install PIPOPTIONS  -r requirements.txt'),
             mock.call('. ./venv/bin/activate && python setup.py develop')
         ])
 

--- a/tests/unit/cirrus/build_tests.py
+++ b/tests/unit/cirrus/build_tests.py
@@ -77,8 +77,6 @@ class BuildCommandTests(unittest.TestCase):
         self.mock_pypirc = self.pypirc_patcher.start()
         self.mock_pypirc.return_value = self.mock_pypirc_inst
 
-
-
         self.mock_pypi_auth.return_value = {
             'username': 'PYPIUSERNAME',
             'ssh_username': 'SSHUSERNAME',
@@ -130,8 +128,6 @@ class BuildCommandTests(unittest.TestCase):
             mock.call('. ./venv/bin/activate && python setup.py develop')
         ])
 
-
-
     def test_execute_build_default_pypi_pip_options(self):
         """test execute_build with default pypi settings"""
         opts = mock.Mock()
@@ -144,7 +140,7 @@ class BuildCommandTests(unittest.TestCase):
 
         self.mock_local.assert_has_calls([
             mock.call('CIRRUS_HOME/venv/bin/virtualenv CWD/venv'),
-            mock.call('CWD/venv/bin/pip install PIPOPTIONS  -r requirements.txt'),
+            mock.call('CWD/venv/bin/pip install -r requirements.txt PIPOPTIONS '),
             mock.call('. ./venv/bin/activate && python setup.py develop')
         ])
 

--- a/tests/unit/cirrus/pypirc_tests.py
+++ b/tests/unit/cirrus/pypirc_tests.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+"""
+test coverage for pypirc module
+"""
+import os
+import tempfile
+import unittest
+
+from cirrus.pypirc import PypircFile
+
+PYPIRC = \
+"""
+[distutils]
+index-servers =
+  pypi
+  devpi
+
+[pypi]
+repository: https://pypi.python.org/pypi/
+username: steve
+password: stevespass
+
+[devpi]
+repository: https://localhost:4000
+username: the_steve
+password: stevespass
+
+"""
+
+
+class PypircFileTest(unittest.TestCase):
+    """test coverage for PypircFile class"""
+    def setUp(self):
+        """make a test pypirc file"""
+        self.dir = tempfile.mkdtemp()
+        self.file = os.path.join(self.dir, '.pypirc')
+        with open(self.file, 'w') as handle:
+            handle.write(PYPIRC)
+
+    def tearDown(self):
+        if os.path.exists(self.dir):
+            os.system('rm -rf {}'.format(self.dir))
+
+    def test_pypircfile(self):
+        """test loading file and accessing data"""
+
+        pypirc = PypircFile(self.file)
+        self.failUnless(pypirc.exists())
+
+        self.failUnless('pypi' in pypirc.index_servers)
+        self.failUnless('devpi' in pypirc.index_servers)
+
+        self.assertEqual(
+            pypirc.get_pypi_url('pypi'),
+            "https://steve:stevespass@https://pypi.python.org/pypi//simple"
+        )
+        self.assertEqual(
+            pypirc.get_pypi_url('devpi'),
+            "https://the_steve:stevespass@https://localhost:4000/simple"
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
@ksnavely @shudgston 

Addressing a lack of flexibility for using multiple pypi servers in the build command. 
This PR:
  - Allows build config for pypi server to use an alias from pypirc 
  - Adds support for arbitrary pip options via package config file like extra-index etc
  - Tests expansion

Fixes #131 