### PR TITLE
Fix `git cirrus docs pack`

### DIFF
--- a/src/cirrus/documentation_utils.py
+++ b/src/cirrus/documentation_utils.py
@@ -112,7 +112,7 @@ def build_doc_artifact():
         raise RuntimeError(msg)
 
     with tarfile.open(artifact_name, "w:gz") as tar:
-        tar.add(doc_dir, arcname=arcname, recursive=False)
+        tar.add(doc_dir, arcname=arcname)
 
     LOGGER.info("Documentation artifact created at: {}".format(artifact_name))
 

--- a/tests/unit/cirrus/documentation_utils_test.py
+++ b/tests/unit/cirrus/documentation_utils_test.py
@@ -67,8 +67,7 @@ class TestDocumentationUtils(unittest.TestCase):
         mock_exists.return_value = True
         with mock.patch('cirrus.documentation_utils.tarfile.open') as mock_tar:
             self.assertTrue(mock_tar.add.called_once_with(
-                self.doc_dir, arcname='cirrus_unittest-1.2.3', recursive=False)
-            )
+                self.doc_dir, arcname='cirrus_unittest-1.2.3'))
 
     @mock.patch('cirrus.documentation_utils.os.path.exists')
     def test_build_doc_artifact_raises(self, mock_exists):


### PR DESCRIPTION
This PR removes "recursive=False" from building the documentation tarball because it actually should be True, otherwise none of the files actually get added to the tarball.

To be honest I'm incredibly confused about making this mistake because I could have sworn when I was testing out using `tarfile.Tarfile().add()` that recursive=False gave me the desired behavior, but using it now it didn't do what I wanted but removing recursive=False did make it work as desired.