### PR TITLE
Feature/package improvements

### DIFF
--- a/src/cirrus/editor_plugin.py
+++ b/src/cirrus/editor_plugin.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+"""
+editor_plugin
+
+Base Plugin for setting up an editor project in a cirrus repo
+
+"""
+import argparse
+
+from pluggage.factory_plugin import PluggagePlugin
+
+from cirrus.configuration import load_configuration
+
+
+class EditorPlugin(PluggagePlugin):
+    """
+    base class for an editor plugin.
+    Subclasses should override the setup method
+    to create the editor IDE template/config
+
+    """
+    PLUGGAGE_FACTORY_NAME = 'editors'
+
+    def __init__(self):
+        super(EditorPlugin, self).__init__()
+        self.config = None
+        self.opts = None
+
+    def run(self, opts):
+        """
+        _run_
+
+        Run the plugin, calling the overloaded parser
+        and setup methods
+        """
+        self.opts = opts
+        project_dir = opts.repo
+        self.config = load_configuration()
+        self.setup(project_dir)
+
+    def setup(self, project_directory):
+        """
+        _setup_
+
+        :param project_directory: Location to set up project
+        for the editor or IDE supported by this plugin
+
+        """
+        msg = "{}.setup is not implemented".format(type(self).__name__)
+        raise NotImplementedError(msg)

--- a/src/cirrus/editor_plugin.py
+++ b/src/cirrus/editor_plugin.py
@@ -5,8 +5,6 @@ editor_plugin
 Base Plugin for setting up an editor project in a cirrus repo
 
 """
-import argparse
-
 from pluggage.factory_plugin import PluggagePlugin
 
 from cirrus.configuration import load_configuration

--- a/src/cirrus/package.py
+++ b/src/cirrus/package.py
@@ -156,7 +156,7 @@ def build_parser(argslist):
     )
     init_command.add_argument(
         '--create-version-file',
-        help='create the file containing __version__ if it doesnt exist',
+        help="create the file containing __version__ if it doesn\'t exist",
         default=False,
         action='store_true'
     )

--- a/src/cirrus/plugins/editors/__init__.py
+++ b/src/cirrus/plugins/editors/__init__.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+"""
+_editors_
+
+Plugins for bootstrapping projects for editors in a cirrus
+package.
+
+Eg:
+ setting up a sublime project with a build system
+ creating a project-root.el file for emacs
+ whatever the hell vi does...
+
+"""
+import sublime

--- a/src/cirrus/plugins/editors/sublime.py
+++ b/src/cirrus/plugins/editors/sublime.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+"""
+_sublime_
+
+Editor plugin that creates a sublime project
+file including a build rule for the cirrus
+virtualenv
+
+"""
+import os
+import inspect
+import pystache
+
+import cirrus.templates
+from cirrus.editor_plugin import EditorPlugin
+from cirrus.logger import get_logger
+
+
+LOGGER = get_logger()
+
+
+class Sublime(EditorPlugin):
+    """
+    Editor plugin that creates a sublime project
+    for the
+
+    """
+    @property
+    def template(self):
+        templ_dir = os.path.dirname(inspect.getsourcefile(cirrus.templates))
+        templ = os.path.join(templ_dir, 'sublime-project.mustache')
+        return templ
+
+    def setup(self, project_directory):
+        """
+        setup
+
+        create a sublime project file from the template
+
+        """
+        package_name = self.config.package_name()
+        project_name = "{}.sublime-project".format(package_name)
+        project_file = os.path.join(project_directory, project_name)
+        LOGGER.info("creating sublime project file: {}".format(project_name))
+        context = {
+            'repo_location': project_directory
+        }
+
+        pypaths = [project_directory]
+        for subdir in self.opts.pythonpath:
+            pypaths.append(os.path.join(project_directory, subdir))
+        context['pythonpath'] = ':'.join(pypaths)
+
+        with open(self.template, 'r') as handle:
+            templ = handle.read()
+
+        rendered = pystache.render(
+            templ, context
+            )
+        with open(project_file, 'w') as handle:
+            handle.write(rendered)

--- a/src/cirrus/plugins/editors/sublime.py
+++ b/src/cirrus/plugins/editors/sublime.py
@@ -22,11 +22,14 @@ LOGGER = get_logger()
 class Sublime(EditorPlugin):
     """
     Editor plugin that creates a sublime project
-    for the
+    for the repo.
+    The project definition file includes
+    a basic build system for the cirrus virtualenv.
 
     """
     @property
     def template(self):
+        """return path to template"""
         templ_dir = os.path.dirname(inspect.getsourcefile(cirrus.templates))
         templ = os.path.join(templ_dir, 'sublime-project.mustache')
         return templ

--- a/src/cirrus/templates/sublime-project.mustache
+++ b/src/cirrus/templates/sublime-project.mustache
@@ -12,7 +12,7 @@
             "working_dir": "${project_path}",
             "shell" : true,
             "env" : {
-                "PYTHONPATH" : "{{repo_location}}"
+                "PYTHONPATH" : "{{pythonpath}}"
             },
             "cmd":
             [

--- a/src/cirrus/utils.py
+++ b/src/cirrus/utils.py
@@ -51,17 +51,23 @@ def update_version(filename, new_version, vers_attr='__version__'):
     _update_version_
 
     Util to update the __version__ field (or different if supplied)
-    in a file with the new version string provided
+    in a file with the new version string provided.
+
+    Will append the version line if not found
 
     """
     lines = []
     with open(filename, 'r') as handle:
         lines = handle.readlines()
 
+    updated = False
     for lineno, line in enumerate(lines):
         if line.startswith(vers_attr):
             lines[lineno] = "{0}=\"{1}\"\n".format(vers_attr, new_version)
+            updated = True
             break
+    if not updated:
+        lines.append("{0}=\"{1}\"\n".format(vers_attr, new_version))
 
     with open(filename, 'w') as handle:
         handle.writelines(lines)


### PR DESCRIPTION
@ksnavely @appeltel @shudgston 

 - Addresses issues found so far in #113 with init file location and update of version attr. 
 - Adds plugin based git cirrus package project command that can be used to init a project for a given editor plugin
 - Adds a sublime project plugin that creates a templated sublime project

Eg:
git cirrus package project -t Sublime  -p src test

with create a <package-name>.sublime-project file in the repo with a build system pointing at the virtualenv from cirrus build and adding src and test dirs to the pythonpath for the build system

