### PR TITLE
Fix package command for remote, fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ cd test_repo/
 git init 
 git checkout -b develop 
 mkdir src
-mkdir throwaway
 mkdir src/throwaway
 echo "__version__ = '0.0.0'\n" > src/throwaway/__init__.py
 echo "requests\n" > requirements.txt

--- a/src/cirrus/package.py
+++ b/src/cirrus/package.py
@@ -211,7 +211,7 @@ def setup_branches(opts):
         branch(opts.repo, opts.develop, opts.master)
         if do_push:
             LOGGER.info("Pushing {}...".format(opts.develop))
-            push()
+            push(opts.repo)
 
     LOGGER.info("Working on {}".format(get_active_branch(opts.repo)))
 


### PR DESCRIPTION
Fix a bug where if git cirrus package init is called with a remote, the call to push() is missing the repo directory argument and fails.

Remove spurious directory creation from the README example for git package init.

Tested this fix by creating a private test repository on my github and running the package init command.