### PR TITLE
Surround = operator in version assignment with spaces per PEP8

### DIFF
--- a/src/cirrus/utils.py
+++ b/src/cirrus/utils.py
@@ -63,11 +63,11 @@ def update_version(filename, new_version, vers_attr='__version__'):
     updated = False
     for lineno, line in enumerate(lines):
         if line.startswith(vers_attr):
-            lines[lineno] = "{0}=\"{1}\"\n".format(vers_attr, new_version)
+            lines[lineno] = "{0} = \"{1}\"\n".format(vers_attr, new_version)
             updated = True
             break
     if not updated:
-        lines.append("{0}=\"{1}\"\n".format(vers_attr, new_version))
+        lines.append("{0} = \"{1}\"\n".format(vers_attr, new_version))
 
     with open(filename, 'w') as handle:
         handle.writelines(lines)


### PR DESCRIPTION
Trying to cleanup PEP8 complaints, but cirrus is just going to re-create one on the next version bump. Specifically cirrus writes out '__version__="foo.bar.baz"', with no spaces around the = operator. AFAICT this shouldn't cause any parsing issues.

@evansde77 @skscharr @ksnavely @jcounts Tired of listing people for this tiny change.