### PR TITLE
Provide a meaningful exit code with the quality control command

### DIFF
--- a/src/cirrus/quality_control.py
+++ b/src/cirrus/quality_control.py
@@ -6,10 +6,10 @@ Command to run quality control via pylint, pep8, pyflakes
 import sys
 from argparse import ArgumentParser
 
-from git_tools import get_diff_files
-from pylint_tools import pep8_file
-from pylint_tools import pyflakes_file
-from pylint_tools import pylint_file
+from cirrus.git_tools import get_diff_files
+from cirrus.pylint_tools import pep8_file
+from cirrus.pylint_tools import pyflakes_file
+from cirrus.pylint_tools import pylint_file
 from cirrus.configuration import load_configuration
 from cirrus.logger import get_logger
 
@@ -24,8 +24,10 @@ def build_parser(argslist):
 
     """
     parser = ArgumentParser(
-        description=('git cirrus qc command: runs pep8, pylint, and pyflakes'
-            'on source code and generates an acceptance code')
+        description=(
+            'git cirrus qc command: runs pep8, pylint, and pyflakes'
+            'on source code and generates an acceptance code'
+        )
     )
     parser.add_argument('qc', nargs='?')
     parser.add_argument(
@@ -47,7 +49,9 @@ def build_parser(argslist):
     opts = parser.parse_args(argslist)
 
     if opts.only_changes and opts.files is not None:
-        raise("Cannot set '--only-changes=True' and provide an list of files")
+        raise ValueError(
+            "Cannot set '--only-changes' and provide an list of files"
+        )
 
     return opts
 
@@ -61,7 +65,7 @@ def run_pylint(files=None):
     config = load_configuration()
     quality_info = ()
     pylint_options = {'rcfile': config.quality_rcfile()}
-    if files == None:  # run on entire package
+    if files is None:  # run on entire package
         quality_info = pylint_file(
             [config.package_name()],
             **pylint_options)
@@ -72,9 +76,11 @@ def run_pylint(files=None):
 
     threshold = config.quality_threshold()
     if quality_info[1] <= threshold:
-        LOGGER.info(("Failed threshold test.  "
-            "Your score: {0}, Threshold {1}".format(
-                quality_info[1], threshold)))
+        LOGGER.info(
+            "Failed threshold test.  "
+            "Your score: {0}, Threshold {1}"
+            .format(quality_info[1], threshold)
+        )
         return False
     else:
         LOGGER.info("Passed threshold test.")
@@ -89,7 +95,7 @@ def run_pyflakes(verbose, files=None):
     """
     config = load_configuration()
     quality_info = ()
-    if files == None:  # run on entire package
+    if files is None:  # run on entire package
         quality_info = pyflakes_file([config.package_name()], verbose=verbose)
     else:
         quality_info = pyflakes_file(files, verbose=verbose)
@@ -111,7 +117,7 @@ def run_pep8(verbose, files=None):
     """
     config = load_configuration()
     quality_info = ()
-    if files == None:  # run on entire package
+    if files is None:  # run on entire package
         quality_info = pep8_file([config.package_name()], verbose=verbose)
     else:
         quality_info = pep8_file(files, verbose=verbose)
@@ -134,7 +140,7 @@ def main():
     opts = build_parser(sys.argv)
     if opts.only_changes:
         files = get_diff_files(None)
-        #we only want python modules
+        # we only want python modules
         for item in files:
             if not item.endswith('.py'):
                 files.remove(item)
@@ -145,7 +151,7 @@ def main():
         files = opts.files
 
     pass_qc = True
-    #run all if none specified
+    # run all if none specified
     if not opts.pylint and not opts.pep8 and not opts.pyflakes:
         pass_qc = run_pep8(opts.verbose, files=files) and pass_qc
         pass_qc = run_pyflakes(opts.verbose, files=files) and pass_qc

--- a/src/cirrus/quality_control.py
+++ b/src/cirrus/quality_control.py
@@ -141,7 +141,7 @@ def main():
     if opts.only_changes:
         files = get_diff_files(None)
         # we only want python modules
-        for item in files:
+        for item in files[:]:
             if not item.endswith('.py'):
                 files.remove(item)
         if not files:
@@ -150,21 +150,21 @@ def main():
     else:
         files = opts.files
 
-    pass_qc = True
+    pass_pep8, pass_pyflakes, pass_pylint = True, True, True
     # run all if none specified
     if not opts.pylint and not opts.pep8 and not opts.pyflakes:
-        pass_qc = run_pep8(opts.verbose, files=files) and pass_qc
-        pass_qc = run_pyflakes(opts.verbose, files=files) and pass_qc
-        pass_qc = run_pylint(files=files) and pass_qc
+        pass_pep8 = run_pep8(opts.verbose, files=files)
+        pass_pyflakes = run_pyflakes(opts.verbose, files=files)
+        pass_pylint = run_pylint(files=files)
     else:
         if opts.pylint:
-            pass_qc = run_pylint(files=files) and pass_qc
+            pass_pylint = run_pylint(files=files)
         if opts.pep8:
-            pass_qc = run_pep8(opts.verbose, files=files) and pass_qc
+            pass_pep8 = run_pep8(opts.verbose, files=files)
         if opts.pyflakes:
-            pass_qc = run_pyflakes(opts.verbose, files=files) and pass_qc
+            pass_pyflakes = run_pyflakes(opts.verbose, files=files)
 
-    if not pass_qc:
+    if not all([pass_pep8, pass_pylint, pass_pyflakes]):
         sys.exit(1)
 
 if __name__ == '__main__':

--- a/tests/unit/cirrus/quality_control_test.py
+++ b/tests/unit/cirrus/quality_control_test.py
@@ -7,6 +7,20 @@ import unittest
 from cirrus.quality_control import run_pep8
 from cirrus.quality_control import run_pyflakes
 from cirrus.quality_control import run_pylint
+from cirrus.quality_control import main
+
+
+def linter_side_effect(result):
+    """
+    Helper function to create a mock side-effect for
+    one of the linter functions (i.e. pep8_file, etc...)
+    the function retured takes a list of filenames
+    and keyword parameters, and returns a tuple
+    with the filename list and fake result as given.
+    """
+    def side_effect(filenames, **kwargs):
+        return filenames, result
+    return side_effect
 
 
 class QualityControlTest(unittest.TestCase):
@@ -17,25 +31,174 @@ class QualityControlTest(unittest.TestCase):
             'cirrus.quality_control.load_configuration')
         self.mock_config = self.patch_config_load.start()
 
+        self.patch_pep8 = mock.patch('cirrus.quality_control.pep8_file')
+        self.mock_pep8 = self.patch_pep8.start()
+        self.patch_pyflakes = mock.patch('cirrus.quality_control.pyflakes_file')
+        self.mock_pyflakes = self.patch_pyflakes.start()
+        self.patch_pylint = mock.patch('cirrus.quality_control.pylint_file')
+        self.mock_pylint = self.patch_pylint.start()
+
+        self.patch_config = mock.patch('cirrus.quality_control.load_configuration')
+        self.mock_config_get = self.patch_config.start()
+        self.mock_config = mock.Mock()
+        self.mock_config.package_name.return_value = 'testpackage'
+        self.mock_config.quality_rcfile.return_value = 'rc_cola'
+        self.mock_config.quality_threshold.return_value = 9.0
+        self.mock_config_get.return_value = self.mock_config
+
+        self.patch_sys = mock.patch('cirrus.quality_control.sys')
+        self.mock_sys = self.patch_sys.start()
+
+        self.patch_get_diff = mock.patch('cirrus.quality_control.get_diff_files')
+        self.mock_diff_files = self.patch_get_diff.start()
+        self.mock_diff_files.return_value = ['bar.ini', 'baz.yml', 'foo.py']
+
     def tearDown(self):
         self.patch_config_load.stop()
+        self.patch_pep8.stop()
+        self.patch_pyflakes.stop()
+        self.patch_pylint.stop()
+        self.patch_config.stop()
+        self.patch_sys.stop()
+        self.patch_get_diff.stop()
 
-    def test_run_pylint(self):
-        with mock.patch('cirrus.quality_control.pylint_file') as mock_pylint:
-            run_pylint()
-            self.failUnless(mock_pylint.called)
+    def test_run_pylint_failure(self):
+        self.mock_pylint.side_effect = linter_side_effect(3.42)
+        result = run_pylint()
+        self.mock_pylint.assert_called_once_with(
+            ['testpackage'],
+            rcfile='rc_cola'
+        )
+        self.assertFalse(result)
 
-    def test_run_pyflakes(self):
-        with mock.patch(
-            'cirrus.quality_control.pyflakes_file') as mock_pyflakes:
+    def test_run_pylint_success(self):
+        self.mock_pylint.side_effect = linter_side_effect(10.0)
+        result = run_pylint()
+        self.mock_pylint.assert_called_once_with(
+            ['testpackage'],
+            rcfile='rc_cola'
+        )
+        self.assertTrue(result)
 
-            run_pyflakes(False)
-            self.failUnless(mock_pyflakes.called)
+    def test_run_pylint_files(self):
+        self.mock_pylint.side_effect = linter_side_effect(10.0)
+        result = run_pylint(files=['foo', 'bar'])
+        self.mock_pylint.assert_called_once_with(
+            ['foo', 'bar'],
+            rcfile='rc_cola'
+        )
+        self.assertTrue(result)
 
-    def test_run_pep8(self):
-        with mock.patch('cirrus.quality_control.pep8_file') as mock_pep8:
-            run_pep8(False)
-            self.failUnless(mock_pep8.called)
+    def test_run_pyflakes_failure(self):
+        self.mock_pyflakes.side_effect = linter_side_effect(3)
+        result = run_pyflakes(False)
+        self.mock_pyflakes.assert_called_once_with(['testpackage'], verbose=False)
+        self.assertFalse(result)
+
+    def test_run_pyflakes_success(self):
+        self.mock_pyflakes.side_effect = linter_side_effect(0)
+        result = run_pyflakes(False)
+        self.mock_pyflakes.assert_called_once_with(['testpackage'], verbose=False)
+        self.assertTrue(result)
+
+    def test_run_pyflakes_files_verbose(self):
+        self.mock_pyflakes.side_effect = linter_side_effect(0)
+        result = run_pyflakes(True, files=['foo', 'bar'])
+        self.mock_pyflakes.assert_called_once_with(['foo', 'bar'], verbose=True)
+        self.assertTrue(result)
+
+    def test_run_pep8_failure(self):
+        self.mock_pep8.side_effect = linter_side_effect(3)
+        result = run_pep8(False)
+        self.mock_pep8.assert_called_once_with(['testpackage'], verbose=False)
+        self.assertFalse(result)
+
+    def test_run_pep8_success(self):
+        self.mock_pep8.side_effect = linter_side_effect(0)
+        result = run_pep8(False)
+        self.mock_pep8.assert_called_once_with(['testpackage'], verbose=False)
+        self.assertTrue(result)
+
+    def test_run_pep8_files_verbose(self):
+        self.mock_pep8.side_effect = linter_side_effect(0)
+        result = run_pep8(True, files=['foo', 'bar'])
+        self.mock_pep8.assert_called_once_with(['foo', 'bar'], verbose=True)
+        self.assertTrue(result)
+
+    def test_qc_command_success(self):
+        self.mock_pep8.side_effect = linter_side_effect(0)
+        self.mock_pyflakes.side_effect = linter_side_effect(0)
+        self.mock_pylint.side_effect = linter_side_effect(10.0)
+        self.mock_sys.argv = ['qc']
+
+        main()
+
+        self.mock_pep8.assert_called_once_with(['testpackage'], verbose=False)
+        self.mock_pyflakes.assert_called_once_with(['testpackage'], verbose=False)
+        self.mock_pylint.assert_called_once_with(['testpackage'], rcfile='rc_cola')
+
+    def test_qc_command_single_failure(self):
+        self.mock_pep8.side_effect = linter_side_effect(0)
+        self.mock_pyflakes.side_effect = linter_side_effect(3)
+        self.mock_pylint.side_effect = linter_side_effect(10.0)
+        self.mock_sys.argv = ['qc']
+
+        main()
+
+        self.mock_sys.exit.assert_called_once_with(1)
+        self.mock_pep8.assert_called_once_with(['testpackage'], verbose=False)
+        self.mock_pyflakes.assert_called_once_with(['testpackage'], verbose=False)
+        self.mock_pylint.assert_called_once_with(['testpackage'], rcfile='rc_cola')
+
+    def test_qc_command_multiple_failure(self):
+        self.mock_pep8.side_effect = linter_side_effect(2)
+        self.mock_pyflakes.side_effect = linter_side_effect(3)
+        self.mock_pylint.side_effect = linter_side_effect(3.4)
+        self.mock_sys.argv = ['qc']
+
+        main()
+
+        self.mock_sys.exit.assert_called_once_with(1)
+        self.mock_pep8.assert_called_once_with(['testpackage'], verbose=False)
+        self.mock_pyflakes.assert_called_once_with(['testpackage'], verbose=False)
+        self.mock_pylint.assert_called_once_with(['testpackage'], rcfile='rc_cola')
+
+    def test_qc_command_only_changes(self):
+        self.mock_pep8.side_effect = linter_side_effect(2)
+        self.mock_pyflakes.side_effect = linter_side_effect(3)
+        self.mock_pylint.side_effect = linter_side_effect(3.4)
+        self.mock_sys.argv = ['qc', '--only-changes']
+
+        main()
+
+        self.mock_sys.exit.assert_called_once_with(1)
+        self.mock_pep8.assert_called_once_with(['foo.py'], verbose=False)
+        self.mock_pyflakes.assert_called_once_with(['foo.py'], verbose=False)
+        self.mock_pylint.assert_called_once_with(['foo.py'], rcfile='rc_cola')
+
+    def test_qc_command_files(self):
+        self.mock_pep8.side_effect = linter_side_effect(2)
+        self.mock_pyflakes.side_effect = linter_side_effect(3)
+        self.mock_pylint.side_effect = linter_side_effect(3.4)
+        self.mock_sys.argv = ['qc', '-f', 'baz.py']
+
+        main()
+
+        self.mock_sys.exit.assert_called_once_with(1)
+        self.mock_pep8.assert_called_once_with(['baz.py'], verbose=False)
+        self.mock_pyflakes.assert_called_once_with(['baz.py'], verbose=False)
+        self.mock_pylint.assert_called_once_with(['baz.py'], rcfile='rc_cola')
+
+    def test_qc_command_changes_and_files_error(self):
+        self.mock_sys.argv = ['qc', '-f', 'baz.py', '--only-changes']
+
+        with self.assertRaises(ValueError):
+            main()
+
+        self.assertFalse(self.mock_pep8.called)
+        self.assertFalse(self.mock_pyflakes.called)
+        self.assertFalse(self.mock_pylint.called)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Set an exit status code for the quality control command. The command will exit 0 if there are no
failures or 1 if any linters resulted in violations or threshold failures. This will make the command more useful in automated linting tests.

Cleanup the quality_control module to pass pep8 / pyflakes / pylint tests. SRSLY!