### PR TITLE
Feature/build venv option

### DIFF
--- a/src/cirrus/build.py
+++ b/src/cirrus/build.py
@@ -69,9 +69,8 @@ def build_parser(argslist):
         help='extra requirements files to install'
     )
     parser.add_argument(
-        '--use-virtualenv', 
-        type=str, 
-        dest='use_venv', 
+        '--use-virtualenv',
+        dest='use_venv',
         help='explicit virtualenv binary to use',
         default=None
         )

--- a/src/cirrus/build.py
+++ b/src/cirrus/build.py
@@ -69,6 +69,13 @@ def build_parser(argslist):
         help='extra requirements files to install'
     )
     parser.add_argument(
+        '--use-virtualenv', 
+        type=str, 
+        dest='use_venv', 
+        help='explicit virtualenv binary to use',
+        default=None
+        )
+    parser.add_argument(
         '--no-setup-develop',
         dest='nosetupdevelop',
         default=False,
@@ -108,11 +115,10 @@ def execute_build(opts):
 
     venv_path = os.path.join(working_dir, venv_name)
     venv_bin_path = os.path.join(venv_path, 'bin', 'python')
-    venv_command = os.path.join(
-        cirrus_home(),
-        'venv',
-        'bin',
-        'virtualenv')
+    if opts.use_venv:
+        venv_command = opts.use_venv
+    else:
+        venv_command = 'virtualenv'
 
     # remove existing virtual env if building clean
     if opts.clean and os.path.exists(venv_path):

--- a/tests/unit/cirrus/build_tests.py
+++ b/tests/unit/cirrus/build_tests.py
@@ -100,11 +100,12 @@ class BuildCommandTests(unittest.TestCase):
         opts.upgrade = False
         opts.extras = []
         opts.nosetupdevelop = False
+        opts.use_venv = None
 
         execute_build(opts)
 
         self.mock_local.assert_has_calls([
-            mock.call('CIRRUS_HOME/venv/bin/virtualenv CWD/venv'),
+            mock.call('virtualenv CWD/venv'),
             mock.call('CWD/venv/bin/pip install -r requirements.txt'),
             mock.call('. ./venv/bin/activate && python setup.py develop')
         ])
@@ -116,6 +117,7 @@ class BuildCommandTests(unittest.TestCase):
         opts.upgrade = False
         opts.extras = []
         opts.nosetupdevelop = False
+        opts.use_venv = None
 
         self.mock_conf.pypi_url.return_value = "dev"
         self.mock_pypirc_inst.index_servers = ['dev']
@@ -123,7 +125,7 @@ class BuildCommandTests(unittest.TestCase):
         execute_build(opts)
 
         self.mock_local.assert_has_calls([
-            mock.call('CIRRUS_HOME/venv/bin/virtualenv CWD/venv'),
+            mock.call('virtualenv CWD/venv'),
             mock.call('CWD/venv/bin/pip install -i DEVPYPIURL -r requirements.txt'),
             mock.call('. ./venv/bin/activate && python setup.py develop')
         ])
@@ -135,11 +137,12 @@ class BuildCommandTests(unittest.TestCase):
         opts.upgrade = False
         opts.extras = []
         opts.nosetupdevelop = False
+        opts.use_venv = None
         self.mock_conf.pip_options.return_value = "PIPOPTIONS"
         execute_build(opts)
 
         self.mock_local.assert_has_calls([
-            mock.call('CIRRUS_HOME/venv/bin/virtualenv CWD/venv'),
+            mock.call('virtualenv CWD/venv'),
             mock.call('CWD/venv/bin/pip install -r requirements.txt PIPOPTIONS '),
             mock.call('. ./venv/bin/activate && python setup.py develop')
         ])
@@ -150,12 +153,13 @@ class BuildCommandTests(unittest.TestCase):
         opts.clean = False
         opts.upgrade = True
         opts.extras = []
+        opts.use_venv = None
         opts.nosetupdevelop = False
 
         execute_build(opts)
 
         self.mock_local.assert_has_calls([
-            mock.call('CIRRUS_HOME/venv/bin/virtualenv CWD/venv'),
+            mock.call('virtualenv CWD/venv'),
             mock.call('CWD/venv/bin/pip install --upgrade -r requirements.txt'),
             mock.call('. ./venv/bin/activate && python setup.py develop')
         ])
@@ -165,11 +169,12 @@ class BuildCommandTests(unittest.TestCase):
         opts = mock.Mock()
         opts.clean = False
         opts.upgrade = False
+        opts.use_venv = None
         opts.extras = ['test-requirements.txt']
         opts.nosetupdevelop = False
         execute_build(opts)
         self.mock_local.assert_has_calls([
-            mock.call('CIRRUS_HOME/venv/bin/virtualenv CWD/venv'),
+            mock.call('virtualenv CWD/venv'),
             mock.call('CWD/venv/bin/pip install -r requirements.txt'),
             mock.call('CWD/venv/bin/pip install -r test-requirements.txt'),
             mock.call('. ./venv/bin/activate && python setup.py develop')
@@ -181,11 +186,12 @@ class BuildCommandTests(unittest.TestCase):
         opts.clean = False
         opts.extras = []
         opts.upgrade = False
+        opts.use_venv = None
         opts.nosetupdevelop = True
 
         execute_build(opts)
         self.mock_local.assert_has_calls([
-            mock.call('CIRRUS_HOME/venv/bin/virtualenv CWD/venv'),
+            mock.call('virtualenv CWD/venv'),
             mock.call('CWD/venv/bin/pip install -r requirements.txt')
         ])
 
@@ -195,13 +201,14 @@ class BuildCommandTests(unittest.TestCase):
         opts.clean = False
         opts.extras = []
         opts.upgrade = False
+        opts.use_venv = None
         opts.nosetupdevelop = False
         self.mock_conf.pypi_url.return_value = "PYPIURL"
 
         execute_build(opts)
 
         self.mock_local.assert_has_calls([
-            mock.call('CIRRUS_HOME/venv/bin/virtualenv CWD/venv'),
+            mock.call('virtualenv CWD/venv'),
             mock.call('CWD/venv/bin/pip install -i https://PYPIUSERNAME:TOKEN@PYPIURL/simple -r requirements.txt'),
             mock.call('. ./venv/bin/activate && python setup.py develop')
 
@@ -212,6 +219,7 @@ class BuildCommandTests(unittest.TestCase):
         opts = mock.Mock()
         opts.clean = False
         opts.extras = []
+        opts.use_venv = None
         opts.nosetupdevelop = False
         opts.upgrade = True
         self.mock_conf.pypi_url.return_value = "PYPIURL"
@@ -219,7 +227,7 @@ class BuildCommandTests(unittest.TestCase):
         execute_build(opts)
 
         self.mock_local.assert_has_calls([
-            mock.call('CIRRUS_HOME/venv/bin/virtualenv CWD/venv'),
+            mock.call('virtualenv CWD/venv'),
             mock.call('CWD/venv/bin/pip install -i https://PYPIUSERNAME:TOKEN@PYPIURL/simple --upgrade -r requirements.txt'),
             mock.call('. ./venv/bin/activate && python setup.py develop')
         ])

--- a/tests/unit/cirrus/build_tests.py
+++ b/tests/unit/cirrus/build_tests.py
@@ -110,6 +110,23 @@ class BuildCommandTests(unittest.TestCase):
             mock.call('. ./venv/bin/activate && python setup.py develop')
         ])
 
+    def test_execute_build_default_pypi_custom_venv(self):
+        """test execute_build with default pypi settings"""
+        opts = mock.Mock()
+        opts.clean = False
+        opts.upgrade = False
+        opts.extras = []
+        opts.nosetupdevelop = False
+        opts.use_venv = "CUSTOM_VENV"
+
+        execute_build(opts)
+
+        self.mock_local.assert_has_calls([
+            mock.call('CUSTOM_VENV CWD/venv'),
+            mock.call('CWD/venv/bin/pip install -r requirements.txt'),
+            mock.call('. ./venv/bin/activate && python setup.py develop')
+        ])
+
     def test_execute_build_pypirc(self):
         """test execute_build with pypirc provided settings"""
         opts = mock.Mock()


### PR DESCRIPTION
@shudgston @ksnavely 

using the cirrus virtualenv binary breaks build when you want to use python 3. This PR addresses that to use the current virtualenv symbol and add a command line opt to specify it 