### PR TITLE
tests for dot package support and add -p to build command

### DIFF
--- a/src/cirrus/build.py
+++ b/src/cirrus/build.py
@@ -80,6 +80,11 @@ def build_parser(argslist):
         default=False,
         action='store_true'
     )
+    parser.add_argument(
+        '--python', '-p',
+        help='Which python to use to create venv',
+        default=None
+    )
     opts = parser.parse_args(argslist)
     return opts
 
@@ -107,6 +112,9 @@ def execute_build(opts):
     venv_name = build_params.get('virtualenv_name', 'venv')
     reqs_name = build_params.get('requirements_file', 'requirements.txt')
     extra_reqs = build_params.get('extra_requirements', '')
+    python_bin = build_params.get('python', None)
+    if opts.python:
+        python_bin = opts.python
     extra_reqs = [x.strip() for x in extra_reqs.split(',') if x.strip()]
     if opts.extras:
         extra_reqs.extend(opts.extras)
@@ -118,6 +126,8 @@ def execute_build(opts):
         venv_command = opts.use_venv
     else:
         venv_command = 'virtualenv'
+    if python_bin:
+        venv_command += ' -p {} '.format(python_bin)
 
     # remove existing virtual env if building clean
     if opts.clean and os.path.exists(venv_path):

--- a/src/cirrus/configuration.py
+++ b/src/cirrus/configuration.py
@@ -108,6 +108,11 @@ class Configuration(dict):
     def has_section(self, section):
         return section in self
 
+    def add_section(self, section):
+        if not self.has_section(section):
+            self[section] = {}
+            self.parser.add_section(section)
+
     def get_param(self, section, param, default=None):
         """
         _get_param_
@@ -209,9 +214,7 @@ class Configuration(dict):
         add docker settings to the config file and update it
 
         """
-        if not self.has_section('docker'):
-            self['docker'] = {}
-            self.parser.add_section('docker')
+        self.add_section('docker')
         self['docker']['dockerstache_template'] = template
         self['docker']['dockerstache_context'] = context
         self['docker']['directory'] = directory

--- a/src/cirrus/package.py
+++ b/src/cirrus/package.py
@@ -134,7 +134,7 @@ def build_parser(argslist):
     )
     init_command.add_argument(
         '--pypi-package-name',
-        help='Name for package on upload to pypi, use if different to package option',
+        help='Name for package on upload to pypi, use if different from package option',
         default=None
     )
 
@@ -167,7 +167,7 @@ def build_parser(argslist):
     )
     init_command.add_argument(
         '--python',
-        help='optionally specifiy the name of python binary to use in this package, eg python2, python3',
+        help='optionally specify the name of python binary to use in this package, eg python2, python3',
         default=None
     )
     init_command.add_argument(
@@ -427,7 +427,7 @@ def write_cirrus_conf(opts, version_file):
     backup_file(cirrus_conf)
     pname = opts.package
     if opts.pypi_package_name:
-        pname =opts.pypi_package_name
+        pname = opts.pypi_package_name
     config = ConfigParser.ConfigParser()
     config.add_section('package')
     config.set('package', 'name', pname)

--- a/src/cirrus/package_container.py
+++ b/src/cirrus/package_container.py
@@ -25,7 +25,7 @@ DOCKER_PRE_SCRIPT = \
 """#!/bin/bash
 echo "this is the dockerstache pre render script"
 echo "it runs in the following environment before rendering tempates"
-printenv
+printenv | grep DOCKERSTACHE
 
 """
 
@@ -33,7 +33,7 @@ DOCKER_POST_SCRIPT = \
 """#!/bin/bash
 echo "this is the dockerstache post render script"
 echo "it runs in the following environment after rendering tempates"
-printenv
+printenv | grep DOCKERSTACHE
 {copy_dist}
 
 """

--- a/tests/unit/cirrus/build_tests.py
+++ b/tests/unit/cirrus/build_tests.py
@@ -101,6 +101,7 @@ class BuildCommandTests(unittest.TestCase):
         opts.extras = []
         opts.nosetupdevelop = False
         opts.use_venv = None
+        opts.python = None
 
         execute_build(opts)
 
@@ -118,11 +119,30 @@ class BuildCommandTests(unittest.TestCase):
         opts.extras = []
         opts.nosetupdevelop = False
         opts.use_venv = "CUSTOM_VENV"
+        opts.python = None
 
         execute_build(opts)
 
         self.mock_local.assert_has_calls([
             mock.call('CUSTOM_VENV CWD/venv'),
+            mock.call('CWD/venv/bin/pip install -r requirements.txt'),
+            mock.call('. ./venv/bin/activate && python setup.py develop')
+        ])
+
+    def test_execute_build_with_python_(self):
+        """test execute_build with default pypi settings, -p option"""
+        opts = mock.Mock()
+        opts.clean = False
+        opts.upgrade = False
+        opts.extras = []
+        opts.nosetupdevelop = False
+        opts.use_venv = None
+        opts.python = "python3"
+
+        execute_build(opts)
+
+        self.mock_local.assert_has_calls([
+            mock.call('virtualenv -p python3  CWD/venv'),
             mock.call('CWD/venv/bin/pip install -r requirements.txt'),
             mock.call('. ./venv/bin/activate && python setup.py develop')
         ])
@@ -135,6 +155,7 @@ class BuildCommandTests(unittest.TestCase):
         opts.extras = []
         opts.nosetupdevelop = False
         opts.use_venv = None
+        opts.python = None
 
         self.mock_conf.pypi_url.return_value = "dev"
         self.mock_pypirc_inst.index_servers = ['dev']
@@ -155,6 +176,7 @@ class BuildCommandTests(unittest.TestCase):
         opts.extras = []
         opts.nosetupdevelop = False
         opts.use_venv = None
+        opts.python = None
         self.mock_conf.pip_options.return_value = "PIPOPTIONS"
         execute_build(opts)
 
@@ -171,6 +193,7 @@ class BuildCommandTests(unittest.TestCase):
         opts.upgrade = True
         opts.extras = []
         opts.use_venv = None
+        opts.python = None
         opts.nosetupdevelop = False
 
         execute_build(opts)
@@ -187,6 +210,7 @@ class BuildCommandTests(unittest.TestCase):
         opts.clean = False
         opts.upgrade = False
         opts.use_venv = None
+        opts.python = None
         opts.extras = ['test-requirements.txt']
         opts.nosetupdevelop = False
         execute_build(opts)
@@ -204,6 +228,7 @@ class BuildCommandTests(unittest.TestCase):
         opts.extras = []
         opts.upgrade = False
         opts.use_venv = None
+        opts.python = None
         opts.nosetupdevelop = True
 
         execute_build(opts)
@@ -219,6 +244,7 @@ class BuildCommandTests(unittest.TestCase):
         opts.extras = []
         opts.upgrade = False
         opts.use_venv = None
+        opts.python = None
         opts.nosetupdevelop = False
         self.mock_conf.pypi_url.return_value = "PYPIURL"
 
@@ -239,6 +265,7 @@ class BuildCommandTests(unittest.TestCase):
         opts.use_venv = None
         opts.nosetupdevelop = False
         opts.upgrade = True
+        opts.python = None
         self.mock_conf.pypi_url.return_value = "PYPIURL"
 
         execute_build(opts)


### PR DESCRIPTION
allow for separate package name, setting python interpreter

Continue to improve the container init command, include some additional options for controling package names and python interpreters