### PR TITLE
add release status command

### DIFF
--- a/containers/py2.7/clone_test.sh
+++ b/containers/py2.7/clone_test.sh
@@ -46,9 +46,10 @@ git cirrus feature new test_integ
 git cirrus feature merge
 
 git cirrus release new --micro --no-remote
+git cirrus release status
 git cirrus release build                  # create a build artifact to add to the container
 git cirrus release merge --cleanup --no-remote
-
+git cirrus release status --release=release/0.0.5
 
 
 

--- a/containers/py3.5/clone_test.sh
+++ b/containers/py3.5/clone_test.sh
@@ -44,9 +44,10 @@ git cirrus feature new test_integ
 git cirrus feature merge
 
 git cirrus release new --micro --no-remote
+git cirrus release status 
 git cirrus release build            
 git cirrus release merge --cleanup --no-remote
-
+git cirrus release status --release=release/0.0.5
 
 
 

--- a/src/cirrus/configuration.py
+++ b/src/cirrus/configuration.py
@@ -160,6 +160,9 @@ class Configuration(dict):
     def gitflow_master_name(self):
         return self.get('gitflow', {}).get('master_branch', 'master')
 
+    def gitflow_origin_name(self):
+        return self.get('gitflow', {}).get('remote_origin', 'origin')
+
     def gitflow_feature_prefix(self):
         return self.get('gitflow', {}).get('feature_branch_prefix', 'feature/')
 

--- a/src/cirrus/github_tools.py
+++ b/src/cirrus/github_tools.py
@@ -462,6 +462,56 @@ class GitHubContext(object):
         if plusone:
             self.plus_one_pull_request(pr_data=pr_data, context=plusonecontext)
 
+    def find_release_commit(self, release_branch_or_tag):
+        """
+        attempt to find a matching commit for a branch or tag
+
+        :returns: commit sha string or None if not found
+        """
+        try:
+            commit = self.repo.git.log(release_branch_or_tag, n=1, format="format:%H")
+            return commit.strip()
+        except git.exc.GitCommandError as ex:
+            if "unknown revision" in str(ex):
+                return None
+            raise
+
+    def commit_on_branches(self, commit):
+        """
+        return a list of branches that contain the provided commit
+        """
+
+        branches = self.repo.git.branch(a=True, contains=commit)
+        return branches
+
+    def is_commit_on_branch(self, commit, branch):
+        """
+        return True/False if commit SHA is on branch
+
+        """
+        return branch in self.commit_on_branches(commit)
+
+    def merge_base(self, tag, branch):
+        """
+        get the ancestor commit of tag and branch or None
+        if not found
+        """
+        try:
+            commit = self.repo.git.merge_base(tag, branch)
+            return str(commit).strip()
+        except git.exc.GitCommandError as ex:
+            if "Not a valid object" in str(ex):
+                return None
+            raise
+
+    def git_show_commit(self, commit):
+        """
+        get details string from git show for a given commit
+        """
+        details = self.repo.git.show(commit)
+        return str(details)
+
+
 
 def branch_status(branch_name):
     """

--- a/src/cirrus/release.py
+++ b/src/cirrus/release.py
@@ -293,8 +293,8 @@ def build_parser(argslist):
     status_command = subparsers.add_parser('status')
     status_command.add_argument(
         '--release',
-        help='check status of the provided release',
-        required=True
+        help='check status of the provided release, defaults to current branch',
+        default=None
     )
 
     merge_command = subparsers.add_parser('merge')
@@ -833,6 +833,8 @@ def merge_release(opts):
 def show_release_status(opts):
     """check release status"""
     release = opts.release
+    if release is None:
+        release = current_branch(repo_directory())
     result = release_status(release)
     if not result:
         # unmerged/tagged release => exit as error status

--- a/src/cirrus/release_status.py
+++ b/src/cirrus/release_status.py
@@ -51,7 +51,7 @@ def release_status(release):
                 "Are you sure this is a valid release?"
             ).format(release)
             LOGGER.error(msg)
-            return
+            return False
 
         # check the tag commit is present on master and remote master
         tag_present = False

--- a/src/cirrus/release_status.py
+++ b/src/cirrus/release_status.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+"""
+_release_status_
+
+Helper function to determine release status
+
+"""
+from cirrus.environment import repo_directory
+from cirrus.github_tools import GitHubContext
+from cirrus.logger import get_logger
+
+
+LOGGER = get_logger()
+
+
+def release_status(release):
+    """
+    given a release branch name or tag, look at the status
+    of that release based on git history and attempt to
+    check wether it has been fully merged or tagged.
+
+    returns True if the release looks to be successfully merged and tagged
+
+    """
+    with GitHubContext(repo_directory()) as ghc:
+        LOGGER.info("Checking release status for {}".format(release))
+        # work out the branch and tag for the release
+
+        rel_pfix = ghc.config.gitflow_release_prefix()
+        develop_branch = ghc.config.gitflow_branch_name()
+        master_branch = ghc.config.gitflow_master_name()
+        origin_name = ghc.config.gitflow_origin_name()
+        if rel_pfix in release:
+            release_tag = release.split(rel_pfix)[1]
+            release_branch = release
+        else:
+            release_branch = "{}{}".format(rel_pfix, release)
+            release_tag = release
+
+        LOGGER.info("Checking: branch={} tag={}".format(release_branch, release_tag))
+        branch_commit = ghc.find_release_commit(release_branch)
+        tag_commit = ghc.find_release_commit(release_tag)
+        LOGGER.info("Resolved Commits: branch={} tag={}".format(branch_commit, tag_commit))
+
+        # handles caser where tag or release is not present, eg typo
+        if (not tag_commit) and (not branch_commit):
+            msg = (
+                "Unable to find any branch or tag commits "
+                "for release \'{}\'\n"
+                "Are you sure this is a valid release?"
+            ).format(release)
+            LOGGER.error(msg)
+            return
+
+        # check the tag commit is present on master and remote master
+        tag_present = False
+        if tag_commit:
+            branches = ghc.commit_on_branches(tag_commit)
+            remote_master = "remotes/{}/{}".format(origin_name, master_branch)
+            on_master = master_branch in branches
+            on_origin = remote_master in branches
+            if on_master:
+                LOGGER.info("Tag is present on local master {}...".format(master_branch))
+                tag_present = True
+            if on_origin:
+                LOGGER.info("Tag is present on remote master {}...".format(remote_master))
+                tag_present = True
+
+        # look for common merge base containing the release name for master
+        # and develop
+        develop_merge = ghc.merge_base(release_tag, develop_branch)
+        master_merge = ghc.merge_base(release_tag, master_branch)
+        merge_on_develop = False
+        merge_on_master = False
+        if develop_merge:
+            merge_on_develop = release_branch in ghc.git_show_commit(develop_merge)
+        if master_merge:
+            merge_on_master = release_branch in ghc.git_show_commit(master_merge)
+
+        if merge_on_develop:
+            LOGGER.info("Merge of {} is on {}".format(release_branch, develop_branch))
+        else:
+            LOGGER.info("Merge of {} not found on {}".format(release_branch, develop_branch))
+        if merge_on_master:
+            LOGGER.info("Merge of {} is on {}".format(release_branch, master_branch))
+        else:
+            LOGGER.info("Merge of {} not found on {}".format(release_branch, master_branch))
+
+        if not all([tag_present, merge_on_develop, merge_on_master]):
+            msg = (
+                "\nRelease branch {} was not found either as a tag or merge "
+                "commit on develop branch: {} or master branch: {} branches\n"
+                "This may mean that the release is still running on a CI platform or "
+                "has errored out. \n"
+                " => Tag Present: {}\n"
+                " => Merged to develop: {}\n"
+                " => Merged to master: {}\n"
+                "\nFor troubleshooting please see: "
+                "https://github.com/evansde77/cirrus/wiki/Troubleshooting#release\n"
+            ).format(
+                release_branch,
+                develop_branch,
+                master_branch,
+                tag_present,
+                merge_on_develop,
+                merge_on_master
+            )
+            LOGGER.error(msg)
+            return False
+        msg = "Release {} looks to be successfully merged and tagged\n".format(release_branch)
+        LOGGER.info(msg)
+        return True

--- a/src/cirrus/release_status.py
+++ b/src/cirrus/release_status.py
@@ -22,6 +22,7 @@ def release_status(release):
     returns True if the release looks to be successfully merged and tagged
 
     """
+    result = False
     with GitHubContext(repo_directory()) as ghc:
         LOGGER.info("Checking release status for {}".format(release))
         # work out the branch and tag for the release
@@ -106,7 +107,9 @@ def release_status(release):
                 merge_on_master
             )
             LOGGER.error(msg)
-            return False
-        msg = "Release {} looks to be successfully merged and tagged\n".format(release_branch)
-        LOGGER.info(msg)
-        return True
+            result = False
+        else:
+            msg = "Release {} looks to be successfully merged and tagged\n".format(release_branch)
+            LOGGER.info(msg)
+            result = True
+    return result

--- a/tests/unit/cirrus/release_status_tests.py
+++ b/tests/unit/cirrus/release_status_tests.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+"""
+tests for release status module
+"""
+
+import unittest
+import mock
+
+from cirrus.release_status import release_status
+
+
+class ReleaseStatusTests(unittest.TestCase):
+    """
+    test case for release status
+    """
+
+    def setUp(self):
+        self.patch_ghc = mock.patch('cirrus.release_status.GitHubContext')
+        self.mock_ghc = mock.Mock()
+        self.mock_ghc_ctor = self.patch_ghc.start()
+        mock_ghc_ctx = mock.Mock()
+        mock_ghc_ctx.__enter__ = mock.Mock(return_value=self.mock_ghc)
+        mock_ghc_ctx.__exit__ = mock.Mock()
+        self.mock_ghc_ctor.return_value = mock_ghc_ctx
+        self.mock_conf = mock.Mock()
+        self.mock_conf.gitflow_release_prefix = mock.Mock(return_value='release/')
+        self.mock_conf.gitflow_branch_name = mock.Mock(return_value='develop')
+        self.mock_conf.gitflow_master_name = mock.Mock(return_value='master')
+        self.mock_conf.gitflow_origin_name = mock.Mock(return_value='origin')
+        self.mock_ghc.config = self.mock_conf
+
+        self.mock_ghc.find_release_commit = mock.Mock(side_effect=["BRANCH_COMMIT", "TAG_COMMIT"])
+        self.mock_ghc.commit_on_branches = mock.Mock(return_value=['master', 'remotes/origin/master'])
+        self.mock_ghc.merge_base = mock.Mock(return_value="MERGE_COMMIT")
+        self.mock_ghc.git_show_commit = mock.Mock(return_value=" this contains release/0.2.3 blah")
+
+    def tearDown(self):
+        self.patch_ghc.start()
+
+    def test_release_status(self):
+        """test succesful release status with tag name"""
+        self.assertTrue(release_status('0.2.3'))
+
+    def test_release_status_branch(self):
+        """test successful release status with branch name"""
+        self.assertTrue(release_status('release/0.2.3'))
+
+    def test_bad_release_tag(self):
+        """verify bad tag/release branch"""
+        self.mock_ghc.find_release_commit.side_effect = [None, None]
+        self.assertTrue(not release_status('0.2.3'))
+
+    def test_missing_merges(self):
+        self.mock_ghc.merge_base.return_value = None
+        self.assertTrue(not release_status('0.2.3'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/cirrus/release_status_tests.py
+++ b/tests/unit/cirrus/release_status_tests.py
@@ -35,7 +35,7 @@ class ReleaseStatusTests(unittest.TestCase):
         self.mock_ghc.git_show_commit = mock.Mock(return_value=" this contains release/0.2.3 blah")
 
     def tearDown(self):
-        self.patch_ghc.start()
+        self.patch_ghc.stop()
 
     def test_release_status(self):
         """test succesful release status with tag name"""


### PR DESCRIPTION
Lays out basic release status command to show status of releases and merges and tagging underlying it. 

Addresses https://github.com/evansde77/cirrus/issues/169
