### PR TITLE
Suppress installer error

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -12,13 +12,13 @@ INSTALL_DIR="${HOME}/.cirrus"
 DEFAULT_USER="${USER}"
 
 # prerequisites are pip and virtualenv
-pip --version
+pip --version 2>/dev/null
 if [ $? -eq 127 ]; then
     echo "pip binary not found, cannot proceed"
     exit 127
 fi
 
-virtualenv --version
+virtualenv --version 2>/dev/null
 if [ $? -eq 127 ]; then
     echo "virtualenv binary not found, cannot proceed"
     exit 127


### PR DESCRIPTION
Without venv installed:
```
$ bash installer.sh 
pip 9.0.1 from /Library/Python/2.7/site-packages (python 2.7)
installer.sh: line 21: virtualenv: command not found
virtualenv binary not found, cannot proceed
```
Suppress stderr (but leave stdout)