### PR TITLE
WIP: Feature/package pypirc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,12 +6,13 @@ mock==1.0.1
 nose==1.3.0
 pep8==1.5.7
 pylint==1.3.0
-requests==2.3.0
+requests==2.18.3
 PyChef==0.2.3
 keyring==8.5.1
 virtualenv-api==2.1.16
 virtualenv
-pluggage
+twine==1.9.1
+pluggage==0.0.4
 dockerstache>=0.0.12
-requests-toolbelt==0.6.2
-tox
+requests-toolbelt==0.8.0
+tox=2.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ twine==1.9.1
 pluggage==0.0.4
 dockerstache>=0.0.12
 requests-toolbelt==0.8.0
-tox=2.7.0
+tox==2.7.0

--- a/src/cirrus/_2to3.py
+++ b/src/cirrus/_2to3.py
@@ -34,6 +34,7 @@ if PY2:
     import ConfigParser
     import __builtin__ as builtins
     get_raw_input = raw_input
+    from urlparse import urlparse
 
     def unicode_(s):
         return unicode(s)
@@ -42,6 +43,7 @@ else:
     import configparser as ConfigParser
     import builtins
     get_raw_input = input
+    from urllib.parse import urlparse
 
     def unicode_(s):
         return str(s)

--- a/src/cirrus/package.py
+++ b/src/cirrus/package.py
@@ -29,8 +29,10 @@ from argparse import ArgumentParser
 
 from cirrus.logger import get_logger
 from cirrus.utils import working_dir
+from cirrus.environment import repo_directory
 from cirrus.package_container import init_container
 from cirrus.utils import update_version
+from cirrus.invoke_helpers import local
 from cirrus.pypirc import PypircFile
 from cirrus.git_tools import (
     branch,
@@ -144,6 +146,14 @@ def build_parser(argslist):
         help='Use pypirc to add install options to pip commands',
         default=False,
         action='store_true'
+    )
+    init_command.add_argument(
+        '--register-with-pypi',
+        help=(
+            "Set this to the name of a pypi repo in your pypirc "
+            "to register the new package with that server"
+        ),
+        default=None
     )
 
     init_command.add_argument(
@@ -468,16 +478,18 @@ def write_cirrus_conf(opts, version_file):
         )
     if opts.use_pypirc:
         rcfile = PypircFile()
+        pip_opts = rcfile.pip_options()
+        LOGGER.info("Adding pip options to cirrus.conf: {}".format(pip_opts))
         config.set(
             'build',
             'pip-options',
-            rcfile.pip_options()
+            pip_opts
         )
         config.add_section('pypi')
         config.set(
             'pypi',
             'pip-options',
-            rcfile.pip_options()
+            pip_opts
         )
 
     config.add_section('test-default')
@@ -656,7 +668,9 @@ def bootstrap_repo(opts):
             install_comm = ""
             if opts.use_pypirc:
                 rcfile = PypircFile()
-                install_comm = "install_command = pip install {} {{opts}} {{package}}".format(rcfile.pip_options())
+                pip_opts = rcfile.pip_options()
+                LOGGER.info("Adding pip options to tox.ini: {}".format(pip_opts))
+                install_comm = "install_command = pip install {} {{opts}} {{package}}".format(pip_opts)
 
             handle.write(
                 TOXFILE.format(
@@ -691,6 +705,15 @@ def bootstrap_repo(opts):
     )
 
 
+def setup_register(pypi_url):
+    LOGGER.info("Running setup.py sdist register...")
+    local(
+        'cd {} && python setup.py sdist register -r {}'.format(
+            repo_directory(), pypi_url
+        )
+    )
+
+
 def init_package(opts):
     """
     initialise a repo with a basic cirrus setup
@@ -704,6 +727,9 @@ def init_package(opts):
     files = create_files(opts)
     with working_dir(opts.repo):
         commit_and_tag(opts, *files)
+
+    if opts.register_with_pypi:
+        setup_register(opts.register_with_pypi)
 
     msg = (
         "\nA basic cirrus.conf file has been added to your package\n"

--- a/src/cirrus/pypirc.py
+++ b/src/cirrus/pypirc.py
@@ -4,7 +4,7 @@
 
 """
 import os
-from cirrus._2to3 import ConfigParser
+from cirrus._2to3 import ConfigParser, urlparse
 from cirrus.configuration import get_pypi_auth
 
 
@@ -100,3 +100,26 @@ class PypircFile(dict):
             "https://{username}:{password}@{repository}/simple"
         ).format(**params)
         return url
+
+    def pip_options(self):
+        """
+        create pip options string using --extra-index-url and
+        --trusted-host for each index server
+        """
+        result = ""
+        hosts = set()
+        for idx in self.index_servers:
+            repo = self[idx].get('repository')
+            if not repo:
+                continue
+            result += ' --extra-index-url={}'.format(repo)
+            netloc = urlparse(repo).netloc
+            if ':' in netloc:
+                netloc = netloc.split(':', 1)[0]
+            hosts.add(netloc)
+
+        for host in hosts:
+            if host == 'localhost':
+                continue
+            result += ' --trusted-host={}'.format(host)
+        return result

--- a/src/cirrus/twine_helpers.py
+++ b/src/cirrus/twine_helpers.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+"""
+_twine_helpers_
+
+Helper functions around the Twine CLI/API
+
+"""
+
+from cirrus.configuration import load_configuration
+from twine.commands.register import register
+from twine.commands.upload import upload
+
+
+def register_package(
+        package,
+        repository,
+        pypirc='~/.pypirc',
+        username=None,
+        password=None,
+        certfile=None,
+        client_certfile=None,
+        comment=None
+        ):
+    """
+    :param package: - sdist/bdist etc artifact to register
+    :param repository:
+
+    """
+    cirrus_conf = load_configuration()
+    if cirrus_conf.has_section('twine'):
+        username = username or cirrus_conf.get_param('twine', 'username', None)
+        password = password or cirrus_conf.get_param('twine', 'password', None)
+        certfile = certfile or cirrus_conf.get_param('twine', 'certfile', None)
+        client_certfile = client_certfile or cirrus_conf.get_param('twine', 'client_certfile', None)
+
+    register(
+        package,
+        repository,
+        username,
+        password,
+        comment,
+        pypirc,
+        certfile,
+        client_certfile,
+        None
+    )
+
+
+def upload_package(
+        package,
+        repository,
+        pypirc='~/.pypirc',
+        sign=False,
+        identity=None,
+        username=None,
+        password=None,
+        comment=None,
+        sign_with=None,
+        skip_existing=False,
+        certfile=None,
+        client_certfile=None
+        ):
+    """
+    :param package: path to sdist package
+    :param repository: repo name to upload to
+    :param pypirc: path to pypirc file
+
+    """
+    cirrus_conf = load_configuration()
+    if cirrus_conf.has_section('twine'):
+        username = username or cirrus_conf.get_param('twine', 'username', None)
+        password = password or cirrus_conf.get_param('twine', 'password', None)
+        certfile = certfile or cirrus_conf.get_param('twine', 'certfile', None)
+        identity = identity or cirrus_conf.get_param('twine', 'identity', None)
+        sign_with = sign_with or cirrus_conf.get_param('twine', 'sign_with', None)
+        client_certfile = client_certfile or cirrus_conf.get_param('twine', 'client_certfile', None)
+
+    upload(
+        [package],
+        repository,
+        sign,
+        identity,
+        username,
+        password,
+        comment,
+        sign_with,
+        pypirc,
+        skip_existing,
+        certfile,
+        client_certfile,
+        None
+    )


### PR DESCRIPTION
This PR adds some helpers to make it easier to use multiple pypi servers with a new package during setup. 

- Include the --extra-index-url and --trusted-host settings in pip options for build and tox files based on content of users pypirc file. 
- Add twine and initial code wrapper, plus prototype register via twine in package init command