### PR TITLE
Fix issue where a None argument breaks PypircFile

### DIFF
--- a/src/cirrus/pypirc.py
+++ b/src/cirrus/pypirc.py
@@ -65,7 +65,9 @@ class PypircFile(dict):
     wrapper object for a pypirc file
 
     """
-    def __init__(self, filename='~/.pypirc'):
+    def __init__(self, filename=None):
+        if filename is None:
+            filename = '~/.pypirc'
         self.config_file = os.path.expanduser(filename)
         if self.exists():
             self.load()

--- a/tests/unit/cirrus/pypirc_tests.py
+++ b/tests/unit/cirrus/pypirc_tests.py
@@ -60,6 +60,10 @@ class PypircFileTest(unittest.TestCase):
             "https://the_steve:stevespass@https://localhost:4000/simple"
         )
 
+    def test_pypircfile_uses_default_filename_when_passed_none(self):
+        pypirc = PypircFile(filename=None)
+        self.assertTrue(pypirc.config_file.endswith('.pypirc'))
+
     def test_bad_pypi_name(self):
         pypirc = PypircFile(self.file)
         self.assertRaises(RuntimeError, pypirc.get_pypi_url, 'WOMP')


### PR DESCRIPTION
Default the PypircFile constructor's keyword argument 'filename' to
None, and if None then set to '~/.pypirc`.

Previously it was possible for None values to slip into
os.path.expanduser(), resulting in an AttributeError: 'NoneType'
object has no attribute 'startswith'.

Fixes issue #185