### PR TITLE
Feature/update container init

### DIFF
--- a/src/cirrus/docker.py
+++ b/src/cirrus/docker.py
@@ -175,6 +175,16 @@ def build_parser():
         default=False,
         action='store_true'
     )
+    build_command.add_argument(
+        '--local-test',
+        help=(
+            'install latest dist tarball from ./dist into container '
+            'instead of pip installing from remote pypi '
+            'Run `git cirrus release build` prior to this to get your latest code '
+            'installed for testing'),
+        default=False,
+        action='store_true'
+    )
 
     push_command = subparsers.add_parser('push')
     push_command.add_argument(
@@ -395,6 +405,16 @@ def docker_build(opts, config):
     helper = BuildOptionHelper(opts, config)
     templ = helper['template']
     path = helper['directory']
+
+    if opts.local_test:
+        #
+        # local test => override build args
+        # assumes that the container-init stuff has been used
+        local_tar = '/opt/{package}-latest.tar.gz'.format(
+            package=config.package_name()
+        )
+        LOGGER.info("Local test build will install latest source tarball from dist...")
+        helper['build_arg']['LOCAL_INSTALL'] = local_tar
 
     if helper['login']:
         check = _docker_login(helper)

--- a/src/cirrus/package.py
+++ b/src/cirrus/package.py
@@ -307,13 +307,13 @@ def build_parser(argslist):
         '--local-install',
         default=False,
         action='store_true',
-        help="Add scripts to install from local dist package on container"
+        help="deprecated, has no effect"
     )
     cont_command.add_argument(
         '--pypi-install',
         default=False,
         action='store_true',
-        help="Add scripts to install latest version of lib from a pypi server"
+        help="Deprecated, has no effect"
     )
     cont_command.add_argument(
         '--no-remote',

--- a/src/cirrus/templates/Dockerfile.mustache
+++ b/src/cirrus/templates/Dockerfile.mustache
@@ -1,0 +1,11 @@
+FROM {{container}}
+MAINTAINER {{maintainer}}
+ADD install_script.sh /opt/install_script.sh
+RUN chmod +x /opt/install_script.sh
+COPY {{package}}-latest.tar.gz /opt/{{package}}-latest.tar.gz
+
+ARG LOCAL_INSTALL=''
+RUN /opt/install_script.sh $LOCAL_INSTALL
+
+
+ENTRYPOINT ["{{entrypoint}}"]

--- a/src/cirrus/templates/install_script.sh.mustache
+++ b/src/cirrus/templates/install_script.sh.mustache
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# installer script either vi pypi server or locally using
+# a dist file passed as argument to this script
+LOCAL=$1
+
+{{virtualenv}}
+
+if [  "${LOCAL}x" == "x" ]; then
+    echo "Installing from pip"
+    pip install {{pip_options}} {{open_brace}}cirrus.configuration.package.name{{close_brace}}=={{open_brace}}cirrus.configuration.package.version{{close_brace}}
+else
+    echo "LOCAL flag is ${LOCAL}"
+    pip install -U $LOCAL {{pip_options}}
+fi

--- a/src/cirrus/templates/post_script.sh.mustache
+++ b/src/cirrus/templates/post_script.sh.mustache
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "this is the dockerstache post render script"
+echo "it runs in the following environment after rendering tempates"
+printenv | grep DOCKERSTACHE

--- a/src/cirrus/templates/pre_script.sh.mustache
+++ b/src/cirrus/templates/pre_script.sh.mustache
@@ -1,0 +1,17 @@
+#!/bin/bash
+echo "this is the dockerstache pre render script"
+echo "it runs in the following environment before rendering tempates"
+printenv | grep DOCKERSTACHE
+
+DIST_FILE=`ls -1t ../dist/{{package}}-*.tar.gz | head -1`
+echo "DIST_FILE=${{open_brace}}DIST_FILE{{close_brace}}"
+if [ ! -f "${{open_brace}}DIST_FILE{{close_brace}}" ]; then
+    echo "No dist file ${{{open_brace}}DIST_FILE{{close_brace}} found"
+    if [ ! -f "${{{open_brace}}DOCKERSTACHE_OUTPUT_PATH{{close_brace}}" ]; then
+        mkdir -p "${{DOCKERSTACHE_OUTPUT_PATH{{close_brace}}"
+    fi
+    echo "no dist" >> "${{open_brace}}DOCKERSTACHE_OUTPUT_PATH{{close_brace}}/{{package}}-latest.tar.gz"
+else
+    echo "copied to ${{open_brace}}DOCKERSTACHE_OUTPUT_PATH{{close_brace}}"
+    cp ${{open_brace}}DIST_FILE{{close_brace}} ${{open_brace}}DOCKERSTACHE_OUTPUT_PATH{{close_brace}}/{{package}}-latest.tar.gz
+fi

--- a/src/cirrus/templates/pre_script.sh.mustache
+++ b/src/cirrus/templates/pre_script.sh.mustache
@@ -4,14 +4,14 @@ echo "it runs in the following environment before rendering tempates"
 printenv | grep DOCKERSTACHE
 
 DIST_FILE=`ls -1t ../dist/{{package}}-*.tar.gz | head -1`
-echo "DIST_FILE=${{open_brace}}DIST_FILE{{close_brace}}"
-if [ ! -f "${{open_brace}}DIST_FILE{{close_brace}}" ]; then
-    echo "No dist file ${{{open_brace}}DIST_FILE{{close_brace}} found"
-    if [ ! -f "${{{open_brace}}DOCKERSTACHE_OUTPUT_PATH{{close_brace}}" ]; then
-        mkdir -p "${{DOCKERSTACHE_OUTPUT_PATH{{close_brace}}"
+echo "DIST_FILE=${DIST_FILE}"
+if [ ! -f "${DIST_FILE}" ]; then
+    echo "No dist file ${DIST_FILE} found"
+    if [ ! -f "${DOCKERSTACHE_OUTPUT_PATH}" ]; then
+        mkdir -p "${DOCKERSTACHE_OUTPUT_PATH}"
     fi
-    echo "no dist" >> "${{open_brace}}DOCKERSTACHE_OUTPUT_PATH{{close_brace}}/{{package}}-latest.tar.gz"
+    echo "no dist" >> "${DOCKERSTACHE_OUTPUT_PATH}/{{package}}-latest.tar.gz"
 else
-    echo "copied to ${{open_brace}}DOCKERSTACHE_OUTPUT_PATH{{close_brace}}"
-    cp ${{open_brace}}DIST_FILE{{close_brace}} ${{open_brace}}DOCKERSTACHE_OUTPUT_PATH{{close_brace}}/{{package}}-latest.tar.gz
+    echo "copied to ${DOCKERSTACHE_OUTPUT_PATH}"
+    cp ${DIST_FILE} ${DOCKERSTACHE_OUTPUT_PATH}/{{package}}-latest.tar.gz
 fi

--- a/tests/unit/cirrus/docker_test.py
+++ b/tests/unit/cirrus/docker_test.py
@@ -40,6 +40,7 @@ class DockerFunctionTests(unittest.TestCase):
         self.opts.docker_repo = None
         self.opts.no_cache = False
         self.opts.build_arg = {}
+        self.opts.local_test = False
 
         self.config = Configuration(None)
         self.config['package'] = {
@@ -93,6 +94,26 @@ class DockerFunctionTests(unittest.TestCase):
                     '-t', 'unittesting/unittesting:latest',
                     '-t', 'unittesting/unittesting:1.2.3',
                     '--build-arg', 'OPTION1=VALUE1',
+                    'vm/docker_image'],
+                stderr=mock.ANY,
+                stdout=mock.ANY
+            )
+        )
+
+    def test_docker_build_args_local_test(self):
+        """test straight docker build call"""
+        self.opts.build_arg = {}
+        self.opts.no_cache = False
+        self.opts.local_test = True
+        dckr.docker_build(self.opts, self.config)
+        self.failUnless(self.mock_popen.wait.called)
+        self.mock_popen.assert_has_calls(
+            mock.call(
+                [
+                    'docker', 'build',
+                    '-t', 'unittesting/unittesting:latest',
+                    '-t', 'unittesting/unittesting:1.2.3',
+                    '--build-arg', 'LOCAL_INSTALL=/opt/unittesting-latest.tar.gz',
                     'vm/docker_image'],
                 stderr=mock.ANY,
                 stdout=mock.ANY

--- a/tests/unit/cirrus/package_container_tests.py
+++ b/tests/unit/cirrus/package_container_tests.py
@@ -24,6 +24,7 @@ class InitContainerTests(unittest.TestCase):
         self.gitconf_str = "cirrus.credential-plugin=default"
         with open(self.cirrus_conf, 'w') as handle:
             handle.write("[package]\n")
+            handle.write("name=steves_package\n")
             handle.write("version=0.0.0\n")
             handle.write("author_email=steve@pbr.com\n")
             handle.write("[pypi]\n")
@@ -79,12 +80,12 @@ class InitContainerTests(unittest.TestCase):
             'Dockerfile.mustache',
             'post_script.sh',
             'pre_script.sh',
-            'local_pip_install.sh.mustache',
-            'pypi_pip_install.sh.mustache'
+            'install_script.sh.mustache'
         ]
         self.failUnless(os.path.exists(templates))
         found = os.listdir(templates)
         for exp in expected_files:
+
             self.failUnless(exp in found)
         dockerfile = os.path.join(templates, 'Dockerfile.mustache')
         with open(dockerfile, 'r') as handle:
@@ -101,23 +102,22 @@ class InitContainerTests(unittest.TestCase):
         self.failUnless('dockerstache_context = container-template/context.json' in conf)
         self.failUnless('directory = container-image' in conf)
 
-        local_install = os.path.join(
+        install_script = os.path.join(
             templates,
-            'local_pip_install.sh.mustache'
+            'install_script.sh.mustache'
         )
-        with open(local_install, 'r') as handle:
+        with open(install_script, 'r') as handle:
             local = handle.read()
+            print(local)
             self.failUnless('. /pyenvy/venvs/data_py2/bin/activate' in local)
             self.failUnless('pip install PIP_OPTS' in local)
-        pypi_install = os.path.join(
-            templates,
-            'pypi_pip_install.sh.mustache'
-        )
-        with open(pypi_install, 'r') as handle:
-            pypi =  handle.read()
-            self.failUnless('pip install PIP_OPTS' in pypi)
-            self.failUnless('. /pyenvy/venvs/data_py2/bin/activate' in pypi)
 
+        pre_script = os.path.join(
+            templates, "pre_script.sh"
+        )
+        with open(pre_script, 'r') as handle:
+            script = handle.read()
+            print(script)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Improve the pip/local installation process to use a standard script capable of both methods of installation. 

deprecates local/pip install options in container-init command and switches to a common set of script templates. 