### PR TITLE
WIP: update for release --skip-existing option

### DIFF
--- a/src/cirrus/github_tools.py
+++ b/src/cirrus/github_tools.py
@@ -548,12 +548,14 @@ class GitHubContext(object):
         return str(details)
 
 
-    def unmerged_releases(self):
+    def unmerged_releases(self, version_only=False):
         develop_branch = self.config.gitflow_branch_name()
         release_pfix = self.config.gitflow_release_prefix()
         outp = str(self.repo.git.branch('--no-merged', develop_branch))
         lines = outp.split()
         result = [l.strip() for l in lines if l.strip().startswith(release_pfix)]
+        if version_only:
+            result = [x.replace(release_pfix, '') for x in result]
         return result
 
 

--- a/src/cirrus/github_tools.py
+++ b/src/cirrus/github_tools.py
@@ -547,7 +547,6 @@ class GitHubContext(object):
         details = self.repo.git.show(commit)
         return str(details)
 
-
     def unmerged_releases(self, version_only=False):
         develop_branch = self.config.gitflow_branch_name()
         release_pfix = self.config.gitflow_release_prefix()
@@ -558,6 +557,11 @@ class GitHubContext(object):
             result = [x.replace(release_pfix, '') for x in result]
         return result
 
+
+def unmerged_releases(repo_dir, version_only=False):
+    with GitHubContext(repo_dir) as ghc:
+        result = ghc.unmerged_releases(version_only)
+    return result
 
 def branch_status(branch_name):
     """

--- a/src/cirrus/github_tools.py
+++ b/src/cirrus/github_tools.py
@@ -548,6 +548,18 @@ class GitHubContext(object):
         return str(details)
 
 
+    def unmerged_releases(self):
+        develop_branch = self.config.gitflow_branch_name()
+        release_pfix = self.config.gitflow_release_prefix()
+        outp = str(self.repo.git.branch('--no-merged', develop_branch))
+        lines = outp.split()
+        result = [l.strip() for l in lines if l.strip().startswith(release_pfix)]
+        return result
+
+
+if __name__ == '__main__':
+    with GitHubContext('/Users/devans/Documents/cirrus') as ghc:
+        print(ghc.unmerged_releases())
 
 def branch_status(branch_name):
     """

--- a/src/cirrus/github_tools.py
+++ b/src/cirrus/github_tools.py
@@ -557,10 +557,6 @@ class GitHubContext(object):
         return result
 
 
-if __name__ == '__main__':
-    with GitHubContext('/Users/devans/Documents/cirrus') as ghc:
-        print(ghc.unmerged_releases())
-
 def branch_status(branch_name):
     """
     _branch_status_

--- a/src/cirrus/release.py
+++ b/src/cirrus/release.py
@@ -21,7 +21,7 @@ from cirrus.git_tools import has_unstaged_changes, current_branch
 from cirrus.git_tools import branch, checkout_and_pull
 from cirrus.git_tools import remote_branch_exists
 from cirrus.git_tools import commit_files_optional_push
-from cirrus.github_tools import GitHubContext
+from cirrus.github_tools import GitHubContext, unmerged_releases
 from cirrus.utils import update_file, update_version, max_version
 from cirrus.logger import get_logger
 from cirrus.plugins.jenkins import JenkinsClient
@@ -471,22 +471,21 @@ def make_new_version(opts):
     #
     if opts.skip_existing:
         # skip any existing unmerged branches
-        with GitHubContext(repo_dir) as ghc:
-            unmerged = ghc.unmerged_releases(version_only=True)
-            if unmerged:
-                LOGGER.info(
-                    (
-                        "Skipping Existing Versions found "
-                        "unmerged_releases: {}"
-                    ).format(
-                        ' '.join(unmerged)
-                    )
+        unmerged = unmerged_releases(repo_dir, version_only=True)
+        if unmerged:
+            LOGGER.info(
+                (
+                    "Skipping Existing Versions found "
+                    "unmerged_releases: {}"
+                ).format(
+                    ' '.join(unmerged)
                 )
-                unmerged.append(current_version)
-                current_version = max_version(*unmerged)
-                LOGGER.info(
-                    "selected current version as {}".format(current_version)
-                )
+            )
+            unmerged.append(current_version)
+            current_version = max_version(*unmerged)
+            LOGGER.info(
+                "selected current version as {}".format(current_version)
+            )
 
     new_version = bump_version_field(current_version, field)
     msg = "Bumping version from {prev} to {new} on branch {branch}".format(
@@ -551,22 +550,21 @@ def new_release(opts):
         curr = current_version
         if opts.skip_existing:
             # skip any existing unmerged branches
-            with GitHubContext(repo_dir) as ghc:
-                unmerged = ghc.unmerged_releases(version_only=True)
-                if unmerged:
-                    LOGGER.info(
-                        (
-                            "Skipping Existing Versions found "
-                            "unmerged_releases: {}"
-                        ).format(
-                            ' '.join(unmerged)
-                        )
+            unmerged = unmerged_releases(repo_dir, version_only=True)
+            if unmerged:
+                LOGGER.info(
+                    (
+                        "Skipping Existing Versions found "
+                        "unmerged_releases: {}"
+                    ).format(
+                        ' '.join(unmerged)
                     )
-                    unmerged.append(current_version)
-                    curr = max_version(*unmerged)
-                    LOGGER.info(
-                        "selected current version as {}".format(curr)
-                    )
+                )
+                unmerged.append(current_version)
+                curr = max_version(*unmerged)
+                LOGGER.info(
+                    "selected current version as {}".format(curr)
+                )
 
         new_version = bump_version_field(curr, field)
 

--- a/src/cirrus/release.py
+++ b/src/cirrus/release.py
@@ -548,8 +548,8 @@ def new_release(opts):
         fields = ['major', 'minor', 'micro']
         mask = [opts.major, opts.minor, opts.micro]
         field = [x for x in itertools.compress(fields, mask)][0]
+        curr = current_version
         if opts.skip_existing:
-            curr = current_version
             # skip any existing unmerged branches
             with GitHubContext(repo_dir) as ghc:
                 unmerged = ghc.unmerged_releases(version_only=True)
@@ -567,7 +567,9 @@ def new_release(opts):
                     LOGGER.info(
                         "selected current version as {}".format(curr)
                     )
-            new_version = bump_version_field(curr, field)
+
+        new_version = bump_version_field(curr, field)
+
 
     # release branch
     branch_name = "{0}{1}".format(

--- a/src/cirrus/release_status.py
+++ b/src/cirrus/release_status.py
@@ -42,8 +42,8 @@ def release_status(release):
             if unmerged:
                 msg += (
                     "Found the following unmerged "
-                    "releases:\n {}\n"
-                ).format('\n'.join(unmerged))
+                    "releases:\n{}\n"
+                ).format('\n '.join(unmerged))
             else:
                 msg += "No unmerged releases found.\n"
             msg += (

--- a/src/cirrus/release_status.py
+++ b/src/cirrus/release_status.py
@@ -5,6 +5,7 @@ _release_status_
 Helper function to determine release status
 
 """
+
 from cirrus.environment import repo_directory
 from cirrus.github_tools import GitHubContext
 from cirrus.logger import get_logger
@@ -31,6 +32,15 @@ def release_status(release):
         develop_branch = ghc.config.gitflow_branch_name()
         master_branch = ghc.config.gitflow_master_name()
         origin_name = ghc.config.gitflow_origin_name()
+
+        if not release.startswith(rel_pfix):
+            msg = (
+                "Branch {release} doesnt look like a release branch\n"
+                "Please checkout the release branch you want to check status of"
+            ).format(release=release)
+            LOGGER.error(msg)
+            return False
+
         if rel_pfix in release:
             release_tag = release.split(rel_pfix)[1]
             release_branch = release

--- a/src/cirrus/release_status.py
+++ b/src/cirrus/release_status.py
@@ -33,6 +33,26 @@ def release_status(release):
         master_branch = ghc.config.gitflow_master_name()
         origin_name = ghc.config.gitflow_origin_name()
 
+        if release in (develop_branch, master_branch):
+            unmerged = ghc.unmerged_releases()
+            msg = (
+                "On Develop or Master Branch {}, "
+                "checking for unmerged releases...\n"
+            ).format(release)
+            if unmerged:
+                msg += (
+                    "Found the following unmerged "
+                    "releases:\n {}\n"
+                ).format('\n'.join(unmerged))
+            else:
+                msg += "No unmerged releases found.\n"
+            msg += (
+                "Please checkout a release branch and re run this command"
+                " for more details about a specific release"
+            )
+            LOGGER.info(msg)
+            return False
+
         if not release.startswith(rel_pfix):
             msg = (
                 "Branch {release} doesnt look like a release branch\n"

--- a/src/cirrus/utils.py
+++ b/src/cirrus/utils.py
@@ -8,6 +8,15 @@ General purpose utils
 import os
 import contextlib
 import codecs
+from distutils.version import StrictVersion
+
+
+def max_version(*versions):
+    """
+    find largest semantic version
+    """
+    max_version = max([StrictVersion(x) for x in versions])
+    return str(max_version)
 
 
 @contextlib.contextmanager

--- a/tests/unit/cirrus/builder_plugin_tests.py
+++ b/tests/unit/cirrus/builder_plugin_tests.py
@@ -71,6 +71,30 @@ class BuilderPluginTest(unittest.TestCase):
         self.assertEqual(plug2.python_bin_for_venv, 'python6.7')
         self.assertEqual(plug2.python_bin_for_conda, '6.7')
 
+    @mock.patch('cirrus.builder_plugin.load_configuration')
+    @mock.patch('cirrus.builder_plugin.repo_directory')
+    @mock.patch('cirrus.builder_plugin.local')
+    @mock.patch('cirrus.builder_plugin.subprocess')
+    def test_python_version(self, mock_subp, mock_local, mock_repo_dir, mock_load_conf):
+        mock_conf = mock.Mock()
+        mock_conf.get = mock.Mock(return_value={
+            'build': {'builder': 'conf'},
+            'extra_requirements': ['test-requirements.txt', 'more-reqs.txt'],
+            'python': 'python6.7'
+        })
+        mock_load_conf.return_value = mock_conf
+        mock_repo_dir.return_value = "REPO"
+        mock_subp.getoutput = mock.Mock(return_value="  Python 3.7.1  ")
+        plug = Builder()
+        v = plug.venv_python_version()
+        self.assertEqual(v.major, 3)
+        self.assertEqual(v.minor, 7)
+        self.assertEqual(v.micro, 1)
+        mock_subp.getoutput.return_value = "Python 3.6.4 :: Anaconda, Inc."
+        v = plug.venv_python_version()
+        self.assertEqual(v.major, 3)
+        self.assertEqual(v.minor, 6)
+        self.assertEqual(v.micro, 4)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/cirrus/distribution.py
+++ b/tests/unit/cirrus/distribution.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+"""
+distribution helpers for building source, egg and wheels
+from packages
+
+"""
+import os
+from cirrus.build import get_builder_plugin
+
+
+class ArtifactBuilder(object):
+
+
+    def __init__(self, config, release):
+        self._config
+        self._release = release
+        self._builder = get_builder_plugin()
+
+    @property
+    def source_artifact(self):
+        artifact_name = "{0}-{1}.tar.gz".format(
+            self._config.package_name(),
+            self._config.package_version()
+        )
+        build_artifact = os.path.join(
+            os.getcwd(),
+            'dist',
+            artifact_name
+        )
+        return build_artifact
+
+def egg_artifact_name(config):
+    """
+    given cirrus config, build the expected
+    artifact name
+    """
+    artifact_name = "{0}-{1}.tar.gz".format(
+        config.package_name(),
+        config.package_version()
+    )
+    build_artifact = os.path.join(
+        os.getcwd(),
+        'dist',
+        artifact_name
+    )
+    return build_artifact
+
+def wheel_artifact_name(config):
+    """
+    given cirrus config, build the expected
+    artifact name
+    """
+    artifact_name = "{0}-{1}.tar.gz".format(
+        config.package_name(),
+        config.package_version()
+    )
+    build_artifact = os.path.join(
+        os.getcwd(),
+        'dist',
+        artifact_name
+    )
+    return build_artifact

--- a/tests/unit/cirrus/release_status_tests.py
+++ b/tests/unit/cirrus/release_status_tests.py
@@ -37,9 +37,13 @@ class ReleaseStatusTests(unittest.TestCase):
     def tearDown(self):
         self.patch_ghc.stop()
 
+    def test_release_status_on_develop(self):
+        """test succesful release status with tag name"""
+        self.assertTrue(not release_status('develop'))
+
     def test_release_status(self):
         """test succesful release status with tag name"""
-        self.assertTrue(release_status('0.2.3'))
+        self.assertTrue(release_status('release/0.2.3'))
 
     def test_release_status_branch(self):
         """test successful release status with branch name"""
@@ -48,7 +52,7 @@ class ReleaseStatusTests(unittest.TestCase):
     def test_bad_release_tag(self):
         """verify bad tag/release branch"""
         self.mock_ghc.find_release_commit.side_effect = [None, None]
-        self.assertTrue(not release_status('0.2.3'))
+        self.assertTrue(not release_status('release/0.2.3'))
 
     def test_missing_merges(self):
         self.mock_ghc.merge_base.return_value = None

--- a/tests/unit/cirrus/release_status_tests.py
+++ b/tests/unit/cirrus/release_status_tests.py
@@ -33,6 +33,7 @@ class ReleaseStatusTests(unittest.TestCase):
         self.mock_ghc.commit_on_branches = mock.Mock(return_value=['master', 'remotes/origin/master'])
         self.mock_ghc.merge_base = mock.Mock(return_value="MERGE_COMMIT")
         self.mock_ghc.git_show_commit = mock.Mock(return_value=" this contains release/0.2.3 blah")
+        self.mock_ghc.unmerged_releases = mock.Mock(return_value=['release/UNMERGED'])
 
     def tearDown(self):
         self.patch_ghc.stop()
@@ -40,6 +41,7 @@ class ReleaseStatusTests(unittest.TestCase):
     def test_release_status_on_develop(self):
         """test succesful release status with tag name"""
         self.assertTrue(not release_status('develop'))
+        self.mock_ghc.unmerged_releases.assert_called()
 
     def test_release_status(self):
         """test succesful release status with tag name"""

--- a/tests/unit/cirrus/release_test.py
+++ b/tests/unit/cirrus/release_test.py
@@ -67,6 +67,7 @@ class ReleaseNewCommandTest(unittest.TestCase):
         opts.minor = False
         opts.nightly = False
         opts.bump = None
+        opts.skip_existing = False
 
         # should create a new minor release, editing
         # the cirrus config in the test dir
@@ -104,6 +105,7 @@ class ReleaseNewCommandTest(unittest.TestCase):
         opts.minor = False
         opts.nightly = True
         opts.bump = None
+        opts.skip_existing = False
 
         # should create a new minor release, editing
         # the cirrus config in the test dir
@@ -136,6 +138,7 @@ class ReleaseNewCommandTest(unittest.TestCase):
         opts.major = False
         opts.minor = False
         opts.nightly = False
+        opts.skip_existing = False
         opts.bump = [['womp', '1.2.3'], ['wibble', '3.4.5']]
 
         # should create a new minor release, editing
@@ -170,6 +173,7 @@ class ReleaseNewCommandTest(unittest.TestCase):
         opts.minor = False
         opts.nightly = False
         opts.bump = None
+        opts.skip_existing = False
         self.assertRaises(RuntimeError, new_release, opts)
 
 


### PR DESCRIPTION
- Add --skip-existing option to release new command to avoid recreating versions in flight in CI 
- tweak release status to bail if the branch isnt a release branch