### PR TITLE
Add support for --pull flag to docker-image build

### DIFF
--- a/src/cirrus/docker.py
+++ b/src/cirrus/docker.py
@@ -88,6 +88,7 @@ class BuildOptionHelper(OptionHelper):
         self['defaults'] = config.get_param('docker', 'dockerstache_defaults', None)
         self['build_arg'] = {}
         self['no_cache'] = config.get_param('docker', 'no_cache', None)
+        self['pull'] = config.get_param('docker', 'pull', None)
         if cli_opts.docker_repo:
             self['docker_repo'] = cli_opts.docker_repo
         if cli_opts.directory:
@@ -98,6 +99,8 @@ class BuildOptionHelper(OptionHelper):
             self['build_arg'].update(cli_opts.build_arg)
         if cli_opts.no_cache:
             self['no_cache'] = True
+        if cli_opts.pull:
+            self['pull'] = True
 
 
 class StoreDictKeyPair(Action):
@@ -177,6 +180,12 @@ def build_parser():
         action='store_true'
     )
     build_command.add_argument(
+        '--pull',
+        help='Dont use cached base docker image for build, re-pull base image from docker-registry',
+        default=False,
+        action='store_true'
+    )
+    build_command.add_argument(
         '--local-test',
         help=(
             'install latest dist tarball from ./dist into container '
@@ -223,6 +232,8 @@ def _docker_build(path, tags, base_tag, build_helper):
     command = ['docker', 'build'] + _build_tag_opts(tags)
     if build_helper['no_cache']:
         command.append('--no-cache')
+    if build_helper['pull']:
+        command.append('--pull')
     if build_helper['build_arg']:
         for k, v in build_helper['build_arg'].items():
             command.extend(["--build-arg", "{}={}".format(k, v)])

--- a/tests/unit/cirrus/docker_test.py
+++ b/tests/unit/cirrus/docker_test.py
@@ -39,6 +39,7 @@ class DockerFunctionTests(unittest.TestCase):
         self.opts.dockerstache_defaults = None
         self.opts.docker_repo = None
         self.opts.no_cache = False
+        self.opts.pull = False
         self.opts.build_arg = {}
         self.opts.local_test = False
 
@@ -133,6 +134,26 @@ class DockerFunctionTests(unittest.TestCase):
                     '-t', 'unittesting/unittesting:latest',
                     '-t', 'unittesting/unittesting:1.2.3',
                     '--no-cache',
+                    '--build-arg', 'OPTION1=VALUE1',
+                    'vm/docker_image'],
+                stderr=mock.ANY,
+                stdout=mock.ANY
+            )
+        )
+
+    def test_docker_build_pull(self):
+        """test straight docker build call with --pull"""
+        self.opts.build_arg = {"OPTION1": "VALUE1"}
+        self.opts.pull = True
+        dckr.docker_build(self.opts, self.config)
+        self.failUnless(self.mock_popen.wait.called)
+        self.mock_popen.assert_has_calls(
+            mock.call(
+                [
+                    'docker', 'build',
+                    '-t', 'unittesting/unittesting:latest',
+                    '-t', 'unittesting/unittesting:1.2.3',
+                    '--pull',
                     '--build-arg', 'OPTION1=VALUE1',
                     'vm/docker_image'],
                 stderr=mock.ANY,


### PR DESCRIPTION
This flag makes the docker build command re-pull the base docker image
from the registry instead of using an existing local image. This is
necessary if you want to ensure you have the latest base image.